### PR TITLE
Add utilities for x64 compiler

### DIFF
--- a/compiler/x64/BUILD
+++ b/compiler/x64/BUILD
@@ -1,0 +1,39 @@
+cc_library(
+    name = "x64",
+    srcs = [
+        "register_tracker.cc",
+        "runtime_stack.cc",
+    ],
+    hdrs = [
+        "register_tracker.h",
+        "runtime_stack.h",
+    ],
+    deps = [
+        "//core:value",
+        "//third_party/absl/container:fixed_array",
+        "//third_party/asmjit",
+    ],
+)
+
+cc_test(
+  name = "register_tracker_test",
+  srcs = [
+    "register_tracker_test.cc",
+  ],
+  deps = [
+    "//third_party/gtest:gtest_main",
+    "//third_party/absl/container:flat_hash_set",
+    ":x64",
+  ],
+)
+
+cc_test(
+  name = "runtime_stack_test",
+  srcs = [
+    "runtime_stack_test.cc",
+  ],
+  deps = [
+    "//third_party/gtest:gtest_main",
+    ":x64",
+  ],
+)

--- a/compiler/x64/register_tracker.cc
+++ b/compiler/x64/register_tracker.cc
@@ -1,0 +1,20 @@
+#include "compiler/x64/register_tracker.h"
+
+#include <cstddef>
+
+namespace wasmcc::x64 {
+
+std::optional<asmjit::x86::Gp> RegisterTracker::TakeUnusedRegister() {
+  for (const asmjit::x86::Gp& reg : kCallerSavedRegisters) {
+    if (!_registers_used_mask.test(reg.id())) {
+      _registers_used_mask.set(reg.id());
+      return reg;
+    }
+  }
+  return std::nullopt;
+}
+
+void RegisterTracker::MarkRegisterUnused(const asmjit::x86::Gp& reg) {
+  _registers_used_mask.reset(reg.id());
+}
+}  // namespace wasmcc::x64

--- a/compiler/x64/register_tracker.h
+++ b/compiler/x64/register_tracker.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <asmjit/asmjit.h>
+
+#include <array>
+#include <bitset>
+#include <optional>
+
+namespace wasmcc::x64 {
+
+/**
+ * This class tracks if a given register is in use.
+ *
+ * In the future this class will also likely need to track **where** a register
+ * is in use. So we don't have to do things like always save arguments to the
+ * stack.
+ */
+class RegisterTracker {
+ public:
+  RegisterTracker() = default;
+  RegisterTracker(const RegisterTracker&) = delete;
+  RegisterTracker& operator=(const RegisterTracker&) = delete;
+  RegisterTracker(RegisterTracker&&) = delete;
+  RegisterTracker& operator=(RegisterTracker&&) = delete;
+  ~RegisterTracker() = default;
+
+  /**
+   * Currently, we only use caller saved registers, but we should certainly also
+   * be able to use save callee registers too to resolve some register pressure.
+   */
+  static constexpr std::array kCallerSavedRegisters = {
+      // Function argument #1 in 64-bit Linux.
+      asmjit::x86::rdi,
+      // Function argument #2 in 64-bit Linux.
+      asmjit::x86::rsi,
+      // Function argument #3 in 64-bit Linux.
+      asmjit::x86::rdx,
+      // Function argument #4 in 64-bit Linux.
+      asmjit::x86::rcx,
+      // Function argument #5 in 64-bit Linux.
+      asmjit::x86::r8,
+      // Function argument #6 in 64-bit Linux.
+      asmjit::x86::r9,
+      asmjit::x86::r10,
+      asmjit::x86::r11,
+      // Values are returned from functions in this register.
+      asmjit::x86::rax,
+  };
+  static constexpr size_t kNumGeneralPurposeRegisters = 16;
+  using RegisterUsedMask = std::bitset<kNumGeneralPurposeRegisters>;
+
+  std::optional<asmjit::x86::Gp> TakeUnusedRegister();
+
+  void MarkRegisterUnused(const asmjit::x86::Gp&);
+
+ private:
+  RegisterUsedMask _registers_used_mask;
+};
+}  // namespace wasmcc::x64

--- a/compiler/x64/register_tracker_test.cc
+++ b/compiler/x64/register_tracker_test.cc
@@ -1,0 +1,49 @@
+#include "compiler/x64/register_tracker.h"
+
+#include <gtest/gtest-matchers.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <optional>
+#include <vector>
+
+#include "absl/container/flat_hash_set.h"
+#include "gmock/gmock.h"
+
+template <>
+struct std::hash<asmjit::x86::Gp> {
+  std::size_t operator()(asmjit::x86::Gp const& reg) const noexcept {
+    std::size_t h1 = std::hash<uint32_t>{}(reg.id());
+    std::size_t h2 = std::hash<uint32_t>{}(reg.signature().bits());
+    return h1 ^ (h2 << 1U);
+  }
+};
+
+namespace wasmcc::x64 {
+
+TEST(RegisterTracker, AllocatesRegisters) {
+  RegisterTracker rt;
+  auto r1 = rt.TakeUnusedRegister();
+  EXPECT_NE(r1, std::nullopt);
+  auto r2 = rt.TakeUnusedRegister();
+  EXPECT_NE(r2, std::nullopt);
+  EXPECT_NE(r1, r2);
+}
+
+TEST(RegisterTracker, CanAllocateAllRegisters) {
+  RegisterTracker rt;
+  std::vector<asmjit::x86::Gp> registers;
+  while (true) {
+    auto reg = rt.TakeUnusedRegister();
+    if (!reg.has_value()) {
+      break;
+    }
+    registers.push_back(*reg);
+  }
+  absl::flat_hash_set<asmjit::x86::Gp> unique(registers.begin(),
+                                              registers.end());
+  EXPECT_THAT(registers, testing::UnorderedElementsAreArray(unique));
+}
+}  // namespace wasmcc::x64

--- a/compiler/x64/runtime_stack.cc
+++ b/compiler/x64/runtime_stack.cc
@@ -1,0 +1,50 @@
+#include "compiler/x64/runtime_stack.h"
+
+#include <cstdint>
+
+namespace wasmcc::x64 {
+
+size_t RuntimeValue::size_bytes() const {
+  switch (type) {
+    case ValType::kI32:
+      return sizeof(int32_t);
+    case ValType::kI64:
+      return sizeof(int64_t);
+    case ValType::kF32:
+      return sizeof(float);
+    case ValType::kF64:
+      return sizeof(double);
+    case ValType::kV128:
+      return sizeof(int64_t) * 2;
+    case ValType::kFuncRef:
+    case ValType::kExternRef:
+      return sizeof(void*);
+  }
+}
+
+RuntimeStack::RuntimeStack(size_t max_stack_elements, RegisterTracker* tracker)
+    : _reg_tracker(tracker), _stack(max_stack_elements) {
+  // TODO: We'll need this eventually (I think)
+  (void)_reg_tracker;
+}
+
+RuntimeValue* RuntimeStack::Push(RuntimeValue v) {
+  _stack_memory_offset += int64_t(v.size_bytes());
+  v.stack_pointer = _stack_memory_offset;
+  _stack[_stack_size++] = std::move(v);
+  return Peek();
+}
+RuntimeValue RuntimeStack::Pop() {
+  auto top = std::move(_stack[--_stack_size]);
+  _stack_memory_offset -= int64_t(top.size_bytes());
+  return top;
+}
+RuntimeValue* RuntimeStack::Peek() { return &_stack[_stack_size - 1]; }
+const RuntimeValue* RuntimeStack::Peek() const {
+  return &_stack[_stack_size - 1];
+}
+std::span<const RuntimeValue> RuntimeStack::ReverseIterator() const {
+  return {_stack.data(), _stack_size};
+}
+
+}  // namespace wasmcc::x64

--- a/compiler/x64/runtime_stack.h
+++ b/compiler/x64/runtime_stack.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <span>
+
+#include "absl/container/fixed_array.h"
+#include "compiler/x64/register_tracker.h"
+#include "core/value.h"
+
+namespace wasmcc::x64 {
+
+struct RuntimeValue {
+  // The offset relative to the base of the stack in memory where this stack
+  // value can spill to if not in a register.
+  int64_t stack_pointer = 0;
+  // The register that this value is located in.
+  std::optional<asmjit::x86::Gp> reg;
+  // The type of this register
+  ValType type = ValType::kI32;
+
+  bool operator==(const RuntimeValue&) const = default;
+
+  // The size of this value on the stack in bytes.
+  size_t size_bytes() const;
+};
+
+/**
+ * This class tracks what is on the stack during compilation.
+ *
+ * It also is responsible for tracking stack value's location in stack memory.
+ */
+class RuntimeStack {
+  using UnderlyingType = absl::FixedArray<RuntimeValue>;
+
+ public:
+  RuntimeStack(size_t max_stack_elements, RegisterTracker*);
+  RuntimeStack(const RuntimeStack&) = delete;
+  RuntimeStack& operator=(const RuntimeStack&) = delete;
+  RuntimeStack(RuntimeStack&&) = delete;
+  RuntimeStack& operator=(RuntimeStack&&) = delete;
+  ~RuntimeStack() = default;
+
+  RuntimeValue* Push(RuntimeValue);
+  [[nodiscard]] RuntimeValue Pop();
+  RuntimeValue* Peek();
+  const RuntimeValue* Peek() const;
+
+  std::span<const RuntimeValue> ReverseIterator() const;
+
+  // The current offset in bytes from the bottom of current function's stack.
+  size_t pointer() const noexcept { return _stack_memory_offset; }
+
+ private:
+  RegisterTracker* _reg_tracker;
+  // The current pointer to the stack in memory, relative to the top of the
+  // stack for this calling frame.
+  int64_t _stack_memory_offset{0};
+  // The current stack size
+  size_t _stack_size{0};
+  UnderlyingType _stack;
+};
+
+}  // namespace wasmcc::x64

--- a/compiler/x64/runtime_stack_test.cc
+++ b/compiler/x64/runtime_stack_test.cc
@@ -1,0 +1,45 @@
+#include "compiler/x64/runtime_stack.h"
+
+#include <gtest/gtest-matchers.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <optional>
+#include <vector>
+
+#include "core/value.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace wasmcc::x64 {
+
+constexpr size_t kDefaultStackElements = 32;
+
+TEST(RuntimeStack, EmptyIterator) {
+  RegisterTracker rt;
+  RuntimeStack s(kDefaultStackElements, &rt);
+  EXPECT_THAT(s.ReverseIterator(), testing::IsEmpty());
+}
+
+TEST(RuntimeStack, Push) {
+  RegisterTracker rt;
+  RuntimeStack s(kDefaultStackElements, &rt);
+  auto pushed = s.Push({.type = ValType::kI64});
+  EXPECT_EQ(s.pointer(), sizeof(int64_t));
+  EXPECT_EQ(pushed->stack_pointer, s.pointer());
+  EXPECT_THAT(s.ReverseIterator(), testing::ElementsAre(*pushed));
+}
+
+TEST(RuntimeStack, Pop) {
+  RegisterTracker rt;
+  RuntimeStack s(kDefaultStackElements, &rt);
+  s.Push({.type = ValType::kI64});
+  auto popped = s.Pop();
+  EXPECT_EQ(popped.type, ValType::kI64);
+  EXPECT_EQ(s.pointer(), 0);
+  EXPECT_THAT(s.ReverseIterator(), testing::IsEmpty());
+}
+
+}  // namespace wasmcc::x64

--- a/third_party/absl/container/BUILD
+++ b/third_party/absl/container/BUILD
@@ -1,0 +1,19 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+[
+    alias(
+        name = container,
+        actual = "@com_google_absl//absl/container:" + container,
+    )
+    for container in [
+        "fixed_array",
+        "inlined_vector",
+        "flat_hash_map",
+        "flat_hash_set",
+        "node_hash_map",
+        "node_hash_set",
+        "btree",
+    ]
+]


### PR DESCRIPTION
Add utilities for x64 compiler

When compiling code we'll need to keep track of the current spot in stack memory as well as where registers are allocated.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/rockwotj/wasmcc/pull/4).
* #5
* __->__ #4