### PR TITLE
Add x64::Compiler

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,2 @@
+.sl
+external

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,27 +1,11 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,cert-*,cppcoreguidelines-*,hicpp-*,modernize-*,performance-*,misc-*,bugprone-*,abseil-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-hicpp-named-parameter,-cppcoreguidelines-pro-type-union-access'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,cert-*,cppcoreguidelines-*,hicpp-*,modernize-*,performance-*,misc-*,bugprone-*,abseil-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-hicpp-named-parameter'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false
 FormatStyle:    file
 CheckOptions:
-  - key:             cert-dcl16-c.NewSuffixes
-    value:           'L;LL;LU;LLU'
-  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
-    value:           0
-  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
-    value:           1
-  - key:             misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
-    value:           1
-  - key:             modernize-loop-convert.MaxCopySize
-    value:           16
-  - key:             modernize-loop-convert.MinConfidence
-    value:           reasonable
-  - key:             modernize-pass-by-value.IncludeStyle
-    value:           llvm
-  - key:             modernize-replace-auto-ptr.IncludeStyle
-    value:           llvm
-  - key:             modernize-use-nullptr.NullMacros
-    value:           NULL
+- key:             misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+  value:           1
 ...
 

--- a/compiler/BUILD
+++ b/compiler/BUILD
@@ -1,6 +1,7 @@
 cc_library(
     name = "compiler",
     srcs = [
+        "compiler.cc",
         "function.cc",
     ],
     hdrs = [
@@ -9,6 +10,8 @@ cc_library(
     ],
     deps = [
         "//base:coro",
+        "//compiler/common",
+        "//compiler/x64",
         "//core:ast",
     ],
 )

--- a/compiler/common/BUILD
+++ b/compiler/common/BUILD
@@ -8,6 +8,9 @@ cc_library(
         "exception.h",
         "util.h",
     ],
+    visibility = [
+        "//compiler:__subpackages__",
+    ],
     deps = [
         "//third_party/asmjit",
     ],

--- a/compiler/compiler.cc
+++ b/compiler/compiler.cc
@@ -1,0 +1,58 @@
+#include "compiler/compiler.h"
+
+#include <asmjit/asmjit.h>
+
+#include <memory>
+#include <variant>
+
+#include "base/coro.h"
+#include "compiler/common/util.h"
+#include "compiler/function.h"
+#include "compiler/x64/compiler.h"
+
+namespace wasmcc {
+namespace {
+template <typename T>
+class CompilerImpl : public Compiler {
+ public:
+  CompilerImpl() {
+    Check(_code_holder.init(_runtime.environment(), _runtime.cpuFeatures()));
+  };
+
+  co::Future<CompiledFunction> Compile(Function func) override {
+    T func_compiler(func.meta, &_code_holder);
+    func_compiler.Prologue();
+    for (const auto& expr : func.body) {
+      std::visit(func_compiler, expr);
+      co_await co::MaybeYield();
+    }
+    func_compiler.Epilogue();
+    void* compiled = nullptr;
+    Check(_runtime.add(&compiled, &_code_holder));
+    co_return CompiledFunction(compiled);
+  }
+
+  void Release(CompiledFunction compiled) override {
+    _runtime.release(compiled.get());
+  }
+
+ private:
+  asmjit::JitRuntime _runtime;
+  asmjit::CodeHolder _code_holder;
+};
+}  // namespace
+
+std::unique_ptr<Compiler> Compiler::CreateNative() {
+  auto env = asmjit::Environment::host();
+  switch (env.arch()) {
+    case asmjit::Arch::kX64:
+      return std::make_unique<CompilerImpl<x64::Compiler>>();
+    case asmjit::Arch::kAArch64:
+      // TODO: support me
+    default:
+      // TODO: Properly crash
+      __builtin_unreachable();
+  }
+}
+
+}  // namespace wasmcc

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -1,3 +1,6 @@
+#include <memory>
+#include <random>
+
 #include "base/coro.h"
 #include "compiler/function.h"
 #include "core/ast.h"
@@ -11,6 +14,11 @@ namespace wasmcc {
  */
 class Compiler {
  public:
+  /**
+   * Create a compiler using a FunctionCompiler for the current platform.
+   */
+  static std::unique_ptr<Compiler> CreateNative();
+
   Compiler() = default;
   Compiler(const Compiler&) = delete;
   Compiler& operator=(const Compiler&) = delete;

--- a/compiler/x64/BUILD
+++ b/compiler/x64/BUILD
@@ -1,39 +1,47 @@
 cc_library(
     name = "x64",
     srcs = [
+        "compiler.cc",
         "register_tracker.cc",
         "runtime_stack.cc",
     ],
     hdrs = [
+        "compiler.h",
         "register_tracker.h",
         "runtime_stack.h",
     ],
+    visibility = [
+        "//compiler:__pkg__",
+    ],
     deps = [
+        "//compiler/common",
+        "//core:ast",
         "//core:value",
         "//third_party/absl/container:fixed_array",
+        "//third_party/absl/strings:str_format",
         "//third_party/asmjit",
     ],
 )
 
 cc_test(
-  name = "register_tracker_test",
-  srcs = [
-    "register_tracker_test.cc",
-  ],
-  deps = [
-    "//third_party/gtest:gtest_main",
-    "//third_party/absl/container:flat_hash_set",
-    ":x64",
-  ],
+    name = "register_tracker_test",
+    srcs = [
+        "register_tracker_test.cc",
+    ],
+    deps = [
+        ":x64",
+        "//third_party/absl/container:flat_hash_set",
+        "//third_party/gtest:gtest_main",
+    ],
 )
 
 cc_test(
-  name = "runtime_stack_test",
-  srcs = [
-    "runtime_stack_test.cc",
-  ],
-  deps = [
-    "//third_party/gtest:gtest_main",
-    ":x64",
-  ],
+    name = "runtime_stack_test",
+    srcs = [
+        "runtime_stack_test.cc",
+    ],
+    deps = [
+        ":x64",
+        "//third_party/gtest:gtest_main",
+    ],
 )

--- a/compiler/x64/compiler.cc
+++ b/compiler/x64/compiler.cc
@@ -1,0 +1,202 @@
+#include "compiler/x64/compiler.h"
+
+#include <unistd.h>
+
+#include <cstddef>
+#include <memory>
+
+#include "compiler/common/util.h"
+#include "compiler/x64/register_tracker.h"
+#include "compiler/x64/runtime_stack.h"
+#include "core/value.h"
+
+namespace wasmcc::x64 {
+namespace {
+namespace x86 = asmjit::x86;
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static ThrowingErrorHandler kErrorHandler;
+
+x86::Gp Cast(const x86::Gp& reg, ValType vt) {
+  x86::Gp reg32 = reg.r32();
+  x86::Gp reg64 = reg.r64();
+  return IsValType32Bit(vt) ? reg32 : reg64;
+}
+
+asmjit::TypeId ValTypeToId(ValType vt) {
+  switch (vt) {
+    case ValType::kI32:
+      return asmjit::TypeId::kInt32;
+    case ValType::kI64:
+      return asmjit::TypeId::kInt64;
+    case ValType::kF32:
+      return asmjit::TypeId::kFloat32;
+    case ValType::kF64:
+      return asmjit::TypeId::kFloat64;
+    case ValType::kV128:
+      return asmjit::TypeId::kInt8x16;
+    case ValType::kFuncRef:
+    case ValType::kExternRef:
+      return asmjit::TypeId::kUIntPtr;
+    default:
+      __builtin_unreachable();
+  }
+}
+}  // namespace
+
+Compiler::Compiler(Function::Metadata meta, asmjit::CodeHolder* holder)
+    : _locals_size_bytes(0),  // To be calculated
+      _locals_stack_offset(meta.locals.size() +
+                           meta.signature.parameter_types.size()),
+      _reg_tracker(std::make_unique<RegisterTracker>()),
+      _stack(std::make_unique<RuntimeStack>(meta.max_stack_elements,
+                                            _reg_tracker.get())),
+      _meta(std::move(meta)),
+      _asm(holder),
+      _exit_label(_asm.newLabel()) {
+#ifndef NDEBUG
+  _asm.addDiagnosticOptions(asmjit::DiagnosticOptions::kValidateAssembler);
+#endif
+  _asm.setErrorHandler(&kErrorHandler);
+
+  // Initially record the stack offset relative to the bottom of the stack
+  size_t i = 0;
+  for (const auto& type : _meta.signature.parameter_types) {
+    _locals_stack_offset[i++] = _locals_size_bytes;
+    _locals_size_bytes += int32_t(ValTypeSizeBytes(type));
+  }
+  for (const auto& type : _meta.locals) {
+    _locals_stack_offset[i++] = _locals_size_bytes;
+    _locals_size_bytes += int32_t(ValTypeSizeBytes(type));
+  }
+  // Now that we've calculated the full stack size, adjust the offset to be
+  // relative to the top of the stack.
+  for (i = 0; i < _locals_stack_offset.size(); ++i) {
+    _locals_stack_offset[i] -=
+        _locals_size_bytes + int32_t(_meta.max_stack_size_bytes);
+  }
+  // NOTE: This only supports upto 16 arguments.
+  asmjit::FuncSignatureBuilder b;
+  for (ValType vt : _meta.signature.parameter_types) {
+    b.addArg(ValTypeToId(vt));
+  }
+  switch (_meta.signature.result_types.size()) {
+    case 0:
+      b.setRet(asmjit::TypeId::kVoid);
+      break;
+    case 1:
+      b.addArg(ValTypeToId(_meta.signature.result_types.front()));
+    default:
+      // A pointer to a structure of result values
+      b.setRet(asmjit::TypeId::kUIntPtr);
+      break;
+  }
+  asmjit::FuncDetail func_detail;
+  Check(func_detail.init(b, _asm.environment()));
+  Check(_frame.init(func_detail));
+  // TODO: There are cases where it makes sense to save some caller registers:
+  // _frame.setAllDirty(asmjit::RegGroup::kGp);
+  Check(_frame.finalize());
+  _asm.emitProlog(_frame);
+  AnnotateNext("set locals stack space");
+  // rsp -= <stack_size>
+  _asm.sub(x86::regs::rsp, _meta.max_stack_size_bytes + _locals_size_bytes);
+  // TODO: We should lazily spill these onto the stack, and handle passing
+  // values by stack
+  for (size_t i = 0; i < _meta.signature.parameter_types.size(); ++i) {
+    ValType vt = _meta.signature.parameter_types[i];
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+    const auto& reg = Cast(RegisterTracker::kCallerSavedRegisters[i], vt);
+    auto comment = AnnotateNext("SaveLocalToStack(%d)", i);
+    _asm.mov(x86::Mem(x86::regs::rsp, _locals_stack_offset[i]), reg);
+  }
+}
+
+void Compiler::SetLogger(asmjit::Logger* logger) { _asm.setLogger(logger); }
+void Compiler::AnnotateNext(const char* s) { _asm.setInlineComment(s); }
+
+void Compiler::Prologue() {}
+void Compiler::Epilogue() {
+  AnnotateNext("epilog start");
+  _asm.bind(_exit_label);
+  if (!_meta.signature.result_types.empty()) {
+    auto vt = _meta.signature.result_types.front();
+    auto result_reg = Cast(x86::regs::rax, vt);
+    auto v = _stack->Pop();
+    auto stack_top_reg = EnsureInRegister(&v);
+    stack_top_reg = Cast(stack_top_reg, v.type);
+    if (stack_top_reg != result_reg) {
+      _asm.mov(result_reg, stack_top_reg);
+    }
+  }
+  // rsp += <stack size>
+  _asm.add(x86::regs::rsp, _meta.max_stack_size_bytes + _locals_size_bytes);
+  _asm.emitEpilog(_frame);
+}
+
+void Compiler::operator()(op::ConstI32 op) {
+  auto* top = _stack->Push({.type = ValType::kI32});
+  auto reg = EnsureInRegister(top);
+  int32_t v = op.value.AsI32();
+  auto comment = AnnotateNext("ConstI32(%d)", v);
+  // reg = i32
+  _asm.mov(reg.r32(), v);
+}
+void Compiler::operator()(op::AddI32) {
+  auto x2 = _stack->Pop();
+  auto x2_reg = EnsureInRegister(&x2);
+  auto* x1 = _stack->Peek();
+  auto x1_reg = EnsureInRegister(x1);
+  AnnotateNext("AddI32");
+  // x1r += x2r
+  _asm.adc(x1_reg.r32(), x2_reg.r32());
+  _reg_tracker->MarkRegisterUnused(x2_reg);
+}
+void Compiler::operator()(op::GetLocalI32 op) {
+  _stack->Push({.type = ValType::kI32});
+  auto* top = _stack->Peek();
+  top->reg = AllocateRegister();
+  auto offset = _locals_stack_offset[op.idx];
+  auto comment = AnnotateNext("GetLocalI32(%d)", op.idx);
+  _asm.mov(top->reg->r32(), x86::Mem(x86::rsp, offset));
+}
+void Compiler::operator()(op::SetLocalI32 op) {
+  auto v = _stack->Pop();
+  auto v_reg = EnsureInRegister(&v);
+  auto offset = _locals_stack_offset[op.idx];
+  auto comment = AnnotateNext("SetLocalI32(%d)", op.idx);
+  _asm.mov(x86::Mem(x86::rsp, offset), v_reg);
+  _reg_tracker->MarkRegisterUnused(v_reg);
+}
+void Compiler::operator()(op::Return) { _asm.jmp(_exit_label); }
+
+x86::Gp Compiler::AllocateRegister() {
+  std::optional<x86::Gp> reg = _reg_tracker->TakeUnusedRegister();
+  if (reg) {
+    return *reg;
+  }
+  for (auto& v : _stack->ReverseIterator()) {
+    if (!v.reg.has_value()) {
+      continue;
+    }
+    std::swap(reg, v.reg);
+    // Spill the register to the stack.
+    AnnotateNext("spill onto stack");
+    // rsp[sp] = r
+    _asm.mov(x86::Mem(x86::rsp, v.stack_pointer), Cast(*reg, v.type));
+  }
+  ABSL_ASSERT(reg.has_value());
+  return *reg;
+}
+
+x86::Gp Compiler::EnsureInRegister(RuntimeValue* v) {
+  if (!v->reg) {
+    v->reg = AllocateRegister();
+    AnnotateNext("load from stack");
+    // reg = rsp[sp]
+    _asm.mov(Cast(*v->reg, v->type), x86::Mem(x86::rsp, v->stack_pointer));
+  }
+  return *v->reg;
+}
+
+}  // namespace wasmcc::x64

--- a/compiler/x64/compiler.h
+++ b/compiler/x64/compiler.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "absl/strings/str_format.h"
+#include "compiler/x64/register_tracker.h"
+#include "compiler/x64/runtime_stack.h"
+#include "core/ast.h"
+#include "core/instruction.h"
+
+namespace wasmcc::x64 {
+
+/**
+ *
+ * The compiler ahead of time knows it's memory layout. We'll reserve the max
+ * stack depth (TODO we should also remove pumping the stack when taking into
+ * account the available registers). And also reserve space on the stack for
+ * persisting locals as well.
+ *
+ * The locals are stored closer to the top of the stack, so that values that are
+ * passed on the stack don't have to be moved. The stack is then placed after
+ * that, and stack values grow *towards* the locals (as that was simpler to
+ * implement).
+ *
+ * Here is a graphical representation of the stack usage.
+ *
+ *  ┌──────────┬───────────────┐
+ *  │  LOCALS  │  STACK        │
+ *  └──────────┴───────────────┘
+ *  0xFFFF                0xFF00
+ */
+class Compiler {
+ public:
+  Compiler(Function::Metadata, asmjit::CodeHolder*);
+  Compiler(const Compiler&) = delete;
+  Compiler& operator=(const Compiler&) = delete;
+  Compiler(Compiler&&) = delete;
+  Compiler& operator=(Compiler&&) = delete;
+  ~Compiler() = default;
+
+  void SetLogger(asmjit::Logger*);
+
+  void Prologue();
+  void Epilogue();
+
+  void operator()(op::ConstI32);
+  void operator()(op::AddI32);
+  void operator()(op::GetLocalI32);
+  void operator()(op::SetLocalI32);
+  void operator()(op::Return);
+
+ private:
+  asmjit::x86::Gp AllocateRegister();
+  asmjit::x86::Gp EnsureInRegister(RuntimeValue*);
+
+  // Annotate the next instruction emitted
+  //
+  // The input string must outlive the next instruction emit, and probably
+  // should only be static strings.
+  void AnnotateNext(const char*);
+
+  // Annotate the next instruction emitted
+  //
+  // the returned string must be alive when the next instruction is emitted
+  // asmjit doesn't free these strings.
+  template <typename... A>
+  [[nodiscard(
+      "the comment must outlie emitting the next instruction")]] std::string
+  AnnotateNext(const absl::FormatSpec<A...>& fmt, A&&... args) {
+    std::string msg = absl::StrFormat(fmt, std::forward<A>(args)...);
+    AnnotateNext(msg.c_str());
+    return msg;
+  }
+
+  // The size of the locals in bytes.
+  int32_t _locals_size_bytes;
+  // A mapping between a local and it's memory offset onto the stack.
+  //
+  // The offset is relative to rsp.
+  absl::FixedArray<int32_t> _locals_stack_offset;
+  std::unique_ptr<RegisterTracker> _reg_tracker;
+  std::unique_ptr<RuntimeStack> _stack;
+
+  Function::Metadata _meta;
+  asmjit::x86::Assembler _asm;
+  asmjit::FuncFrame _frame;
+  asmjit::Label _exit_label;
+};
+
+}  // namespace wasmcc::x64

--- a/compiler/x64/runtime_stack.cc
+++ b/compiler/x64/runtime_stack.cc
@@ -29,21 +29,21 @@ RuntimeStack::RuntimeStack(size_t max_stack_elements, RegisterTracker* tracker)
 }
 
 RuntimeValue* RuntimeStack::Push(RuntimeValue v) {
-  _stack_memory_offset += int64_t(v.size_bytes());
+  _stack_memory_offset += int32_t(v.size_bytes());
   v.stack_pointer = _stack_memory_offset;
   _stack[_stack_size++] = std::move(v);
   return Peek();
 }
 RuntimeValue RuntimeStack::Pop() {
   auto top = std::move(_stack[--_stack_size]);
-  _stack_memory_offset -= int64_t(top.size_bytes());
+  _stack_memory_offset -= int32_t(top.size_bytes());
   return top;
 }
 RuntimeValue* RuntimeStack::Peek() { return &_stack[_stack_size - 1]; }
 const RuntimeValue* RuntimeStack::Peek() const {
   return &_stack[_stack_size - 1];
 }
-std::span<const RuntimeValue> RuntimeStack::ReverseIterator() const {
+std::span<RuntimeValue> RuntimeStack::ReverseIterator() {
   return {_stack.data(), _stack_size};
 }
 

--- a/compiler/x64/runtime_stack.h
+++ b/compiler/x64/runtime_stack.h
@@ -11,7 +11,7 @@ namespace wasmcc::x64 {
 struct RuntimeValue {
   // The offset relative to the base of the stack in memory where this stack
   // value can spill to if not in a register.
-  int64_t stack_pointer = 0;
+  int32_t stack_pointer = 0;
   // The register that this value is located in.
   std::optional<asmjit::x86::Gp> reg;
   // The type of this register
@@ -44,16 +44,16 @@ class RuntimeStack {
   RuntimeValue* Peek();
   const RuntimeValue* Peek() const;
 
-  std::span<const RuntimeValue> ReverseIterator() const;
+  std::span<RuntimeValue> ReverseIterator();
 
   // The current offset in bytes from the bottom of current function's stack.
-  size_t pointer() const noexcept { return _stack_memory_offset; }
+  int32_t pointer() const noexcept { return _stack_memory_offset; }
 
  private:
   RegisterTracker* _reg_tracker;
   // The current pointer to the stack in memory, relative to the top of the
   // stack for this calling frame.
-  int64_t _stack_memory_offset{0};
+  int32_t _stack_memory_offset{0};
   // The current stack size
   size_t _stack_size{0};
   UnderlyingType _stack;

--- a/core/BUILD
+++ b/core/BUILD
@@ -24,3 +24,13 @@ cc_library(
         "//base:named_type",
     ],
 )
+
+cc_test(
+  name = "value_test",
+  srcs = ["value_test.cc"],
+  size = "small",
+  deps = [
+    ":value",
+    "//third_party/gtest:gtest_main",
+  ],
+)

--- a/core/ast.h
+++ b/core/ast.h
@@ -74,6 +74,7 @@ struct Function {
     FunctionSignature signature;
     std::vector<ValType> locals;
     uint32_t max_stack_size_bytes;
+    uint32_t max_stack_elements;
   };
   Metadata meta;
   std::vector<Instruction> body;

--- a/core/instruction.h
+++ b/core/instruction.h
@@ -9,8 +9,8 @@ namespace wasmcc {
 namespace op {
 // Push the constant onto the top of the stack.
 struct ConstI32 {
-  explicit ConstI32(uint32_t v) : value({.i32 = v}) {}
-  explicit ConstI32(int32_t v) : value({.i32 = uint32_t(v)}) {}
+  explicit ConstI32(uint32_t v) : value(Value::U32(v)) {}
+  explicit ConstI32(int32_t v) : value(Value::I32(v)) {}
   explicit ConstI32(Value v) : value(v) {}
   Value value;
 };

--- a/core/value.cc
+++ b/core/value.cc
@@ -1,9 +1,14 @@
 #include "core/value.h"
 
+#include <bits/floatn-common.h>
+
+#include <bit>
+#include <cstdint>
+#include <exception>
 #include <ios>
 
 namespace wasmcc {
-bool is_32bit(ValType vt) {
+bool IsValType32Bit(ValType vt) {
   switch (vt) {
     case ValType::kI32:
     case ValType::kF32:
@@ -14,13 +19,32 @@ bool is_32bit(ValType vt) {
       return false;
   }
 }
-bool is_64bit(ValType vt) {
+bool IsValType64Bit(ValType vt) {
   switch (vt) {
     case ValType::kI64:
     case ValType::kF64:
       return true;
     default:
       return false;
+  }
+}
+size_t ValTypeSizeBytes(ValType vt) {
+  switch (vt) {
+    case ValType::kI32:
+      return sizeof(int32_t);
+    case ValType::kI64:
+      return sizeof(int64_t);
+    case ValType::kF32:
+      return sizeof(float);
+    case ValType::kF64:
+      return sizeof(double);
+    case ValType::kV128:
+      return sizeof(int64_t) * 2;
+    case ValType::kFuncRef:
+    case ValType::kExternRef:
+      return sizeof(intptr_t);
+    default:
+      __builtin_unreachable();
   }
 }
 std::ostream& operator<<(std::ostream& os, ValType vt) {
@@ -43,7 +67,24 @@ std::ostream& operator<<(std::ostream& os, ValType vt) {
   return os << "unknown";
 }
 std::ostream& operator<<(std::ostream& os, Value v) {
-  return os << "0x" << std::hex << std::uppercase << v.i64 << std::nouppercase
-            << std::dec;
+  return os << "0x" << std::hex << std::uppercase << v.AsI64()
+            << std::nouppercase << std::dec;
 }
+
+Value::Value(uint64_t v) : _underlying(v) {}
+Value Value::I32(int32_t v) { return Value(uint64_t(v)); }
+Value Value::U32(uint32_t v) { return Value(uint64_t(v)); }
+Value Value::I64(int64_t v) { return Value(v); }
+Value Value::U64(uint64_t v) { return Value(v); }
+Value Value::F32(float v) { return Value(std::bit_cast<uint32_t>(v)); }
+Value Value::F64(double v) { return Value(std::bit_cast<uint64_t>(v)); }
+
+int32_t Value::AsI32() const { return int32_t(_underlying); }
+uint32_t Value::AsU32() const { return uint32_t(_underlying); }
+int64_t Value::AsI64() const { return int64_t(_underlying); }
+uint64_t Value::AsU64() const { return _underlying; }
+float Value::AsF32() const {
+  return std::bit_cast<float>(uint32_t(_underlying));
+}
+double Value::AsF64() const { return std::bit_cast<double>(_underlying); }
 }  // namespace wasmcc

--- a/core/value.h
+++ b/core/value.h
@@ -16,19 +16,37 @@ enum class ValType : uint8_t {
   kFuncRef = 0x70,
   kExternRef = 0x6F,
 };
-bool is_32bit(ValType);
-bool is_64bit(ValType);
+bool IsValType32Bit(ValType);
+bool IsValType64Bit(ValType);
+size_t ValTypeSizeBytes(ValType);
 
 std::ostream& operator<<(std::ostream&, ValType);
 
 /**
  * See: https://webassembly.github.io/spec/core/syntax/types.html
  */
-union Value {
-  uint32_t i32;
-  uint64_t i64;
-  float f32;
-  double f64;
+class Value {
+ public:
+  Value() = default;
+  static Value I32(int32_t);
+  static Value U32(uint32_t);
+  static Value I64(int64_t);
+  static Value U64(uint64_t);
+  static Value F32(float);
+  static Value F64(double);
+
+  int32_t AsI32() const;
+  uint32_t AsU32() const;
+  int64_t AsI64() const;
+  uint64_t AsU64() const;
+  float AsF32() const;
+  double AsF64() const;
+
+  bool operator==(const Value&) const = default;
+
+ private:
+  explicit Value(uint64_t);
+  uint64_t _underlying;
 };
 std::ostream& operator<<(std::ostream&, ValType);
 }  // namespace wasmcc

--- a/core/value_test.cc
+++ b/core/value_test.cc
@@ -1,0 +1,79 @@
+#include "core/value.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+namespace wasmcc {
+
+void TestRoundtrip(int32_t v) {
+  Value value = Value::I32(v);
+  EXPECT_EQ(value.AsI32(), v);
+}
+
+TEST(ValueTest, I32) {
+  using limits = std::numeric_limits<int32_t>;
+  TestRoundtrip(limits::min());
+  TestRoundtrip(-limits::max());
+  TestRoundtrip(-1);
+  TestRoundtrip(0);
+  TestRoundtrip(1);
+  TestRoundtrip(limits::max());
+}
+
+void TestRoundtrip(uint32_t v) {
+  Value value = Value::U32(v);
+  EXPECT_EQ(value.AsU32(), v);
+}
+
+TEST(ValueTest, U32) {
+  using limits = std::numeric_limits<uint32_t>;
+  TestRoundtrip(limits::min());
+  TestRoundtrip(std::numeric_limits<int32_t>::max());
+  TestRoundtrip(limits::max());
+}
+void TestRoundtrip(int64_t v) {
+  Value value = Value::I64(v);
+  EXPECT_EQ(value.AsI64(), v);
+}
+
+TEST(ValueTest, I64) {
+  using limits = std::numeric_limits<int64_t>;
+  TestRoundtrip(limits::min());
+  TestRoundtrip(-std::numeric_limits<int32_t>::max());
+  TestRoundtrip(-std::numeric_limits<uint32_t>::max());
+  TestRoundtrip(std::numeric_limits<int32_t>::min());
+  TestRoundtrip(std::numeric_limits<uint32_t>::min());
+  TestRoundtrip(std::numeric_limits<int32_t>::max());
+  TestRoundtrip(std::numeric_limits<uint32_t>::max());
+  TestRoundtrip(limits::max());
+}
+void TestRoundtrip(double v) {
+  Value value = Value::F64(v);
+  if (std::isnan(v)) {
+    EXPECT_TRUE(std::isnan(value.AsF64()));
+    EXPECT_EQ(std::signbit(value.AsF64()), std::signbit(v));
+  } else {
+    EXPECT_EQ(value.AsF64(), v);
+  }
+}
+TEST(ValueTest, F64) {
+  using limits = std::numeric_limits<double>;
+  TestRoundtrip(limits::quiet_NaN());
+  TestRoundtrip(limits::signaling_NaN());
+  TestRoundtrip(-limits::quiet_NaN());
+  TestRoundtrip(-limits::signaling_NaN());
+  TestRoundtrip(-limits::infinity());
+  TestRoundtrip(limits::min());
+  TestRoundtrip(std::numeric_limits<int32_t>::min());
+  TestRoundtrip(-limits::epsilon());
+  TestRoundtrip(-0.0);
+  TestRoundtrip(0.0);
+  TestRoundtrip(limits::epsilon());
+  TestRoundtrip(std::numeric_limits<int32_t>::max());
+  TestRoundtrip(std::numeric_limits<uint32_t>::max());
+  TestRoundtrip(limits::max());
+  TestRoundtrip(limits::infinity());
+}
+}  // namespace wasmcc

--- a/parser/validator.cc
+++ b/parser/validator.cc
@@ -4,6 +4,8 @@
 #include <utility>
 #include <vector>
 
+#include "core/value.h"
+
 namespace wasmcc {
 
 ValidationType::ValidationType(ValType vt) : _type(uint8_t(vt)) {}
@@ -27,23 +29,12 @@ bool ValidationType::is_ref() const {
 }
 size_t ValidationType::size_bytes() const {
   switch (_type) {
-    case uint8_t(ValType::kI32):
-      return sizeof(int32_t);
-    case uint8_t(ValType::kI64):
-      return sizeof(uint64_t);
-    case uint8_t(ValType::kF32):
-      return sizeof(float);
-    case uint8_t(ValType::kF64):
-      return sizeof(double);
     case kAnyTypeValue:  // Assume worst case for anytype
-    case uint8_t(ValType::kV128):
       return sizeof(uint64_t) * 2;
     case kAnyRefTypeValue:
-    case uint8_t(ValType::kFuncRef):
-    case uint8_t(ValType::kExternRef):
-      return sizeof(void*);
+      return sizeof(intptr_t);
     default:
-      __builtin_unreachable();
+      return ValTypeSizeBytes(ValType(_type));
   }
 }
 std::ostream& operator<<(std::ostream& os, ValidationType vt) {


### PR DESCRIPTION
Add x64::Compiler

This allows for compiling WASM functions at runtime. This will serve as the basis for the API for platform specific compilers.

We're using the standard unix calling convensions and in general are emitting the simplest possible assembly. There are plenty of optimizations to perform.

Arm64 support will follow. We will only support these two architectures (linux or mac).

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/rockwotj/wasmcc/pull/5).
* #7
* #8
* #6
* __->__ #5