### PR TITLE
Add a test utility to parse WAT into WASM

### DIFF
--- a/base/bytes.h
+++ b/base/bytes.h
@@ -1,12 +1,12 @@
 #include <cstdint>
 #include <span>
-#include <string>
+#include <vector>
 
 #pragma once
 
 namespace wasmcc {
 
-using bytes = std::basic_string<uint8_t>;
+using bytes = std::vector<uint8_t>;
 using bytes_view = std::span<uint8_t>;
 
 bool operator==(bytes, bytes_view);

--- a/base/named_type.h
+++ b/base/named_type.h
@@ -27,6 +27,11 @@ class NamedType {
 
   friend bool operator<=>(NamedType<T, Tag>, NamedType<T, Tag>) = default;
 
+  template <typename H>
+  friend H AbslHashValue(H h, const NamedType<T, Tag>& t) {
+    return H::combine(std::move(h), t._value);
+  }
+
  private:
   T _value;
 };

--- a/compiler/BUILD
+++ b/compiler/BUILD
@@ -13,5 +13,6 @@ cc_library(
         "//compiler/common",
         "//compiler/x64",
         "//core:ast",
+        "//third_party/absl/container:flat_hash_map",
     ],
 )

--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -27,6 +27,14 @@ class Compiler {
   virtual ~Compiler() = default;
 
   /**
+   * Compile all parsed functions into machine code for a target architecture.
+   *
+   * NOTE: A compiled function's lifetime is currently managed by the compiler
+   * that created it, but the memory management may change in the future.
+   */
+  virtual co::Future<CompiledModule> Compile(ParsedModule) = 0;
+
+  /**
    * Compile a parsed function into machine code for a target architecture.
    *
    * NOTE: A compiled function's lifetime is currently managed by the compiler
@@ -38,6 +46,10 @@ class Compiler {
    * Free the memory associated with a compiled function.
    */
   virtual void Release(CompiledFunction) = 0;
+  /**
+   * Free the memory associated with all compiled functions in a module.
+   */
+  virtual co::Future<> Release(CompiledModule) = 0;
 };
 
 }  // namespace wasmcc

--- a/compiler/function.h
+++ b/compiler/function.h
@@ -1,4 +1,10 @@
 #pragma once
+#include <string>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "core/ast.h"
+
 namespace wasmcc {
 /**
  * A strongly typed wrapper around dynamically created code.
@@ -17,6 +23,11 @@ class CompiledFunction {
 
  private:
   void* _ptr;
+};
+
+struct CompiledModule {
+  std::vector<CompiledFunction> functions;
+  absl::flat_hash_map<Name, FuncIdx> exported_functions;
 };
 
 }  // namespace wasmcc

--- a/core/BUILD
+++ b/core/BUILD
@@ -22,15 +22,16 @@ cc_library(
         ":value",
         "//base:bytes",
         "//base:named_type",
+        "//third_party/absl/container:flat_hash_map",
     ],
 )
 
 cc_test(
-  name = "value_test",
-  srcs = ["value_test.cc"],
-  size = "small",
-  deps = [
-    ":value",
-    "//third_party/gtest:gtest_main",
-  ],
+    name = "value_test",
+    size = "small",
+    srcs = ["value_test.cc"],
+    deps = [
+        ":value",
+        "//third_party/gtest:gtest_main",
+    ],
 )

--- a/core/ast.h
+++ b/core/ast.h
@@ -4,6 +4,7 @@
 #include <variant>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "base/bytes.h"
 #include "base/named_type.h"
 #include "instruction.h"
@@ -82,5 +83,7 @@ struct Function {
 
 struct ParsedModule {
   std::vector<Function> functions;
+  absl::flat_hash_map<Name, FuncIdx> exported_functions;
 };
+
 }  // namespace wasmcc

--- a/leb128/leb128.h
+++ b/leb128/leb128.h
@@ -29,7 +29,7 @@ bytes encode(int_type value) {
       } else {
         byte |= leading_bit_mask;
       }
-      output.append(&byte, 1);
+      output.push_back(byte);
     }
   } else {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
@@ -39,7 +39,7 @@ bytes encode(int_type value) {
       if (value != 0) {
         byte |= leading_bit_mask;
       }
-      output.append(&byte, 1);
+      output.push_back(byte);
     } while (value != 0);
   }
 

--- a/parser/BUILD
+++ b/parser/BUILD
@@ -29,6 +29,7 @@ cc_library(
         "//base:stream",
         "//core:ast",
         "//leb128",
+        "//third_party/absl/container:flat_hash_set",
         "//third_party/absl/strings:str_format",
     ],
 )
@@ -39,6 +40,7 @@ cc_test(
     srcs = ["parser_test.cc"],
     deps = [
         ":parser",
+        "//testing:wat",
         "//third_party/gtest:gtest_main",
     ],
 )

--- a/parser/parser_test.cc
+++ b/parser/parser_test.cc
@@ -1,29 +1,33 @@
 #include "parser/parser.h"
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <initializer_list>
 
 #include "base/stream.h"
+#include "gmock/gmock.h"
+#include "testing/wat.h"
 
 namespace wasmcc {
 
 TEST(Parsing, AddFunc) {
-  // |bytes| contains the binary format for the following module:
-  //
-  //     (func (export "add") (param i32 i32) (result i32)
-  //       get_local 0
-  //       get_local 1
-  //       i32.add)
-  //
-  // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
-  bytes buf{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01,
-            0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x03, 0x02, 0x01, 0x00, 0x07,
-            0x07, 0x01, 0x03, 0x61, 0x64, 0x64, 0x00, 0x00, 0x0a, 0x09, 0x01,
-            0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x6a, 0x0b};
-  // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
-  ByteStream s(std::move(buf));
+  std::string_view wat = R"WAT(
+    (module
+      (func $add (param $lhs i32) (param $rhs i32) (result i32)
+        local.get $lhs
+        local.get $rhs
+        i32.add)
+      (export "add" (func $add))
+    )
+  )WAT";
+  ByteStream s(Wat2Wasm(wat));
   auto parsed = ParseModule(&s).get();
+  EXPECT_FALSE(s.HasRemaining());
   EXPECT_EQ(parsed.functions.size(), 1);
+  using ::testing::Pair;
+  using ::testing::UnorderedElementsAre;
+  EXPECT_THAT(parsed.exported_functions,
+              UnorderedElementsAre(Pair(Name("add"), FuncIdx(0))));
 }
 }  // namespace wasmcc

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -1,0 +1,14 @@
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "wat",
+    srcs = ["wat.cc"],
+    hdrs = ["wat.h"],
+    deps = [
+        "//base:bytes",
+        "//third_party/wabt",
+    ],
+)

--- a/testing/wat.cc
+++ b/testing/wat.cc
@@ -1,0 +1,42 @@
+#include "testing/wat.h"
+
+#include <stdexcept>
+
+#include "wabt/binary-writer.h"
+#include "wabt/error-formatter.h"
+#include "wabt/stream.h"
+#include "wabt/validator.h"
+#include "wabt/wast-parser.h"
+
+namespace wasmcc {
+
+namespace {
+constexpr static wabt::Features kFeatures;
+}
+
+bytes Wat2Wasm(std::string_view wat) {
+  wabt::Errors errors;
+  std::unique_ptr<wabt::WastLexer> lexer = wabt::WastLexer::CreateBufferLexer(
+      "testdata.wat", wat.data(), wat.size(), &errors);
+  std::unique_ptr<wabt::Module> mod;
+  wabt::WastParseOptions parse_wast_options(kFeatures);
+  auto result = ParseWatModule(lexer.get(), &mod, &errors, &parse_wast_options);
+  if (Failed(result)) {
+    auto line_finder = lexer->MakeLineFinder();
+    std::string err = wabt::FormatErrorsToString(
+        errors, wabt::Location::Type::Text, line_finder.get());
+    throw std::runtime_error(err);
+  }
+  wabt::MemoryStream stream;
+  wabt::WriteBinaryOptions write_wasm_options(kFeatures,
+                                              /*canonicalize_lebs=*/false,
+                                              /*relocatable=*/false,
+                                              /*write_debug_names=*/false);
+  result = wabt::WriteBinaryModule(&stream, mod.get(), write_wasm_options);
+  if (Failed(result)) {
+    throw std::runtime_error("failed to write binary output");
+  }
+  return std::move(stream.ReleaseOutputBuffer()->data);
+}
+
+}  // namespace wasmcc

--- a/testing/wat.h
+++ b/testing/wat.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string_view>
+
+#include "base/bytes.h"
+
+namespace wasmcc {
+
+/**
+ * Convert a WAT file into it's binary form.
+ *
+ * https://developer.mozilla.org/en-US/docs/WebAssembly/Understanding_the_text_format
+ */
+bytes Wat2Wasm(std::string_view);
+
+}  // namespace wasmcc

--- a/third_party/wabt/wabt.BUILD
+++ b/third_party/wabt/wabt.BUILD
@@ -23,10 +23,12 @@ cc_library(
             "src/*.cc",
             "src/*.c",
             "src/interp/*.cc",
+            "src/prebuilt/*.cc",
         ],
         exclude = [
             "src/test-*.cc",
             "src/interp/interp-wasm-c-api.cc",
+            "src/prebuilt/lexer-keywords.cc",
         ],
     ),
     hdrs = glob([
@@ -39,7 +41,6 @@ cc_library(
     ],
     strip_include_prefix = "include",
     textual_hdrs = glob([
-        "src/prebuilt/*.cc",
     ]),
     deps = [":picosha2"],
     testonly = True,


### PR DESCRIPTION
Add a test utility to parse WAT into WASM

This will be useful to ensure tests are readable.

Also adds exports and export validation to the parser.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/rockwotj/wasmcc/pull/6).
* #7
* #8
* __->__ #6