### PR TITLE
Add initial arm64 compiler

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -3,6 +3,12 @@ package(
 )
 
 cc_library(
+    name = "align",
+    hdrs = ["align.h"],
+    srcs = ["align.cc"],
+)
+
+cc_library(
     name = "named_type",
     hdrs = ["named_type.h"],
 )

--- a/base/align.cc
+++ b/base/align.cc
@@ -1,0 +1,27 @@
+#include "base/align.h"
+
+namespace wasmcc {
+namespace {
+template <typename T>
+T AlignDown(T v, T alignment) {
+  return v & ~(alignment - 1);
+}
+template <typename T>
+T AlignUp(T v, T alignment) {
+  return AlignDown<T>(v + alignment - 1, alignment);
+}
+}  // namespace
+
+uint32_t AlignUp(uint32_t v, uint32_t alignment) {
+  return AlignUp<uint32_t>(v, alignment);
+}
+uint64_t AlignUp(uint64_t v, uint64_t alignment) {
+  return AlignUp<uint64_t>(v, alignment);
+}
+uint32_t AlignDown(uint32_t v, uint32_t alignment) {
+  return AlignDown<uint32_t>(v, alignment);
+}
+uint64_t AlignDown(uint64_t v, uint64_t alignment) {
+  return AlignDown<uint64_t>(v, alignment);
+}
+}  // namespace wasmcc

--- a/base/align.h
+++ b/base/align.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace wasmcc {
+
+/**
+ * Align value up to the nearest 'align' bytes.
+ */
+uint32_t AlignUp(uint32_t, uint32_t alignment);
+uint64_t AlignUp(uint64_t, uint64_t alignment);
+/**
+ * Align value down to the nearest 'align' bytes.
+ */
+uint32_t AlignDown(uint32_t, uint32_t alignment);
+uint64_t AlignDown(uint64_t, uint64_t alignment);
+
+}  // namespace wasmcc

--- a/compiler/BUILD
+++ b/compiler/BUILD
@@ -12,6 +12,7 @@ cc_library(
         "//base:coro",
         "//compiler/common",
         "//compiler/x64",
+        "//compiler/arm64",
         "//core:ast",
         "//third_party/absl/container:flat_hash_map",
     ],
@@ -27,9 +28,5 @@ cc_test(
         "//testing:wat",
         "//parser",
         "//third_party/gtest:gtest_main",
-    ],
-    target_compatible_with = [
-      # TODO: Implement arm64 support
-      "@platforms//cpu:x86_64",
     ],
 )

--- a/compiler/arm64/BUILD
+++ b/compiler/arm64/BUILD
@@ -1,0 +1,48 @@
+cc_library(
+    name = "arm64",
+    srcs = [
+        "compiler.cc",
+        "register_tracker.cc",
+        "runtime_stack.cc",
+    ],
+    hdrs = [
+        "compiler.h",
+        "register_tracker.h",
+        "runtime_stack.h",
+    ],
+    visibility = [
+        "//compiler:__pkg__",
+    ],
+    deps = [
+        "//compiler/common",
+        "//core:ast",
+        "//base:align",
+        "//core:value",
+        "//third_party/absl/container:fixed_array",
+        "//third_party/absl/strings:str_format",
+        "//third_party/asmjit",
+    ],
+)
+
+cc_test(
+    name = "register_tracker_test",
+    srcs = [
+        "register_tracker_test.cc",
+    ],
+    deps = [
+        ":arm64",
+        "//third_party/absl/container:flat_hash_set",
+        "//third_party/gtest:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "runtime_stack_test",
+    srcs = [
+        "runtime_stack_test.cc",
+    ],
+    deps = [
+        ":arm64",
+        "//third_party/gtest:gtest_main",
+    ],
+)

--- a/compiler/arm64/compiler.cc
+++ b/compiler/arm64/compiler.cc
@@ -1,0 +1,207 @@
+#include "compiler/arm64/compiler.h"
+
+#include <unistd.h>
+
+#include <cstddef>
+#include <memory>
+
+#include "base/align.h"
+#include "compiler/arm64/register_tracker.h"
+#include "compiler/arm64/runtime_stack.h"
+#include "compiler/common/util.h"
+#include "core/value.h"
+
+namespace wasmcc::arm64 {
+namespace {
+namespace a64 = asmjit::a64;
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static ThrowingErrorHandler kErrorHandler;
+
+a64::Gp Cast(const a64::Gp& reg, ValType vt) {
+  a64::Gp reg32 = reg.w();
+  a64::Gp reg64 = reg.x();
+  return IsValType32Bit(vt) ? reg32 : reg64;
+}
+
+asmjit::TypeId ValTypeToId(ValType vt) {
+  switch (vt) {
+    case ValType::kI32:
+      return asmjit::TypeId::kInt32;
+    case ValType::kI64:
+      return asmjit::TypeId::kInt64;
+    case ValType::kF32:
+      return asmjit::TypeId::kFloat32;
+    case ValType::kF64:
+      return asmjit::TypeId::kFloat64;
+    case ValType::kV128:
+      return asmjit::TypeId::kInt8x16;
+    case ValType::kFuncRef:
+    case ValType::kExternRef:
+      return asmjit::TypeId::kUIntPtr;
+    default:
+      __builtin_unreachable();
+  }
+}
+}  // namespace
+
+Compiler::Compiler(Function::Metadata meta, asmjit::CodeHolder* holder)
+    : _locals_size_bytes(0),  // To be calculated
+      _locals_stack_offset(meta.locals.size() +
+                           meta.signature.parameter_types.size()),
+      _reg_tracker(std::make_unique<RegisterTracker>()),
+      _stack(std::make_unique<RuntimeStack>(meta.max_stack_elements,
+                                            _reg_tracker.get())),
+      _meta(std::move(meta)),
+      _asm(holder),
+      _exit_label(_asm.newLabel()) {
+#ifndef NDEBUG
+  _asm.addDiagnosticOptions(asmjit::DiagnosticOptions::kValidateAssembler);
+#endif
+  _asm.setErrorHandler(&kErrorHandler);
+
+  // Initially record the stack offset relative to the bottom of the stack
+  size_t i = 0;
+  for (const auto& type : _meta.signature.parameter_types) {
+    _locals_stack_offset[i++] = _locals_size_bytes;
+    _locals_size_bytes += int32_t(ValTypeSizeBytes(type));
+  }
+  for (const auto& type : _meta.locals) {
+    _locals_stack_offset[i++] = _locals_size_bytes;
+    _locals_size_bytes += int32_t(ValTypeSizeBytes(type));
+  }
+  // Now that we've calculated the full stack size, adjust the offset to be
+  // relative to the top of the stack.
+  for (i = 0; i < _locals_stack_offset.size(); ++i) {
+    _locals_stack_offset[i] -=
+        _locals_size_bytes + int32_t(_meta.max_stack_size_bytes);
+  }
+  // NOTE: This only supports upto 16 arguments.
+  asmjit::FuncSignatureBuilder b;
+  for (ValType vt : _meta.signature.parameter_types) {
+    b.addArg(ValTypeToId(vt));
+  }
+  switch (_meta.signature.result_types.size()) {
+    case 0:
+      b.setRet(asmjit::TypeId::kVoid);
+      break;
+    case 1:
+      b.addArg(ValTypeToId(_meta.signature.result_types.front()));
+    default:
+      // A pointer to a structure of result values
+      b.setRet(asmjit::TypeId::kUIntPtr);
+      break;
+  }
+  asmjit::FuncDetail func_detail;
+  Check(func_detail.init(b, _asm.environment()));
+  Check(_frame.init(func_detail));
+  // TODO: There are cases where it makes sense to save some caller registers:
+  // _frame.setAllDirty(asmjit::RegGroup::kGp);
+  Check(_frame.finalize());
+  _asm.emitProlog(_frame);
+  AnnotateNext("set locals stack space");
+  // rsp -= <stack_size>
+  _asm.sub(a64::sp, a64::sp,
+           AlignUp(_meta.max_stack_size_bytes + _locals_size_bytes,
+                   _asm.environment().stackAlignment()));
+  // TODO: We should lazily spill these onto the stack, and handle passing
+  // values by stack
+  for (size_t i = 0; i < _meta.signature.parameter_types.size(); ++i) {
+    ValType vt = _meta.signature.parameter_types[i];
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+    const auto& reg = Cast(RegisterTracker::kCallerSavedRegisters[i], vt);
+    auto comment = AnnotateNext("SaveLocalToStack(%d)", i);
+    _asm.str(reg, a64::Mem(a64::regs::sp, _locals_stack_offset[i]));
+  }
+}
+
+void Compiler::SetLogger(asmjit::Logger* logger) { _asm.setLogger(logger); }
+void Compiler::AnnotateNext(const char* s) { _asm.setInlineComment(s); }
+
+void Compiler::Prologue() {}
+void Compiler::Epilogue() {
+  AnnotateNext("epilog start");
+  _asm.bind(_exit_label);
+  if (!_meta.signature.result_types.empty()) {
+    auto vt = _meta.signature.result_types.front();
+    auto result_reg = Cast(a64::regs::x0, vt);
+    auto v = _stack->Pop();
+    auto stack_top_reg = EnsureInRegister(&v);
+    stack_top_reg = Cast(stack_top_reg, v.type);
+    if (stack_top_reg != result_reg) {
+      _asm.mov(result_reg, stack_top_reg);
+    }
+  }
+  // rsp += <stack size>
+  _asm.add(a64::sp, a64::sp,
+           AlignUp(_meta.max_stack_size_bytes + _locals_size_bytes,
+                   _asm.environment().stackAlignment()));
+  _asm.emitEpilog(_frame);
+}
+
+void Compiler::operator()(op::ConstI32 op) {
+  auto* top = _stack->Push({.type = ValType::kI32});
+  auto reg = EnsureInRegister(top);
+  int32_t v = op.value.AsI32();
+  auto comment = AnnotateNext("ConstI32(%d)", v);
+  // reg = i32
+  _asm.mov(reg.w(), v);
+}
+void Compiler::operator()(op::AddI32) {
+  auto x2 = _stack->Pop();
+  auto x2_reg = EnsureInRegister(&x2);
+  auto* x1 = _stack->Peek();
+  auto x1_reg = EnsureInRegister(x1);
+  AnnotateNext("AddI32");
+  // x1r += x2r
+  _asm.add(x1_reg.w(), x1_reg.w(), x2_reg.w());
+  _reg_tracker->MarkRegisterUnused(x2_reg);
+}
+void Compiler::operator()(op::GetLocalI32 op) {
+  _stack->Push({.type = ValType::kI32});
+  auto* top = _stack->Peek();
+  top->reg = AllocateRegister();
+  auto offset = _locals_stack_offset[op.idx];
+  auto comment = AnnotateNext("GetLocalI32(%d)", op.idx);
+  _asm.ldr(top->reg->w(), a64::Mem(a64::sp, offset));
+}
+void Compiler::operator()(op::SetLocalI32 op) {
+  auto v = _stack->Pop();
+  auto v_reg = EnsureInRegister(&v);
+  auto offset = _locals_stack_offset[op.idx];
+  auto comment = AnnotateNext("SetLocalI32(%d)", op.idx);
+  _asm.ldr(v_reg, a64::Mem(a64::sp, offset));
+  _reg_tracker->MarkRegisterUnused(v_reg);
+}
+void Compiler::operator()(op::Return) { _asm.b(_exit_label); }
+
+a64::Gp Compiler::AllocateRegister() {
+  std::optional<a64::Gp> reg = _reg_tracker->TakeUnusedRegister();
+  if (reg) {
+    return *reg;
+  }
+  for (auto& v : _stack->ReverseIterator()) {
+    if (!v.reg.has_value()) {
+      continue;
+    }
+    std::swap(reg, v.reg);
+    // Spill the register to the stack.
+    AnnotateNext("spill onto stack");
+    // rsp[sp] = r
+    _asm.str(Cast(*reg, v.type), a64::Mem(a64::sp, v.stack_pointer));
+  }
+  ABSL_ASSERT(reg.has_value());
+  return *reg;
+}
+
+a64::Gp Compiler::EnsureInRegister(RuntimeValue* v) {
+  if (!v->reg) {
+    v->reg = AllocateRegister();
+    AnnotateNext("load from stack");
+    // reg = rsp[sp]
+    _asm.ldr(Cast(*v->reg, v->type), a64::Mem(a64::sp, v->stack_pointer));
+  }
+  return *v->reg;
+}
+
+}  // namespace wasmcc::arm64

--- a/compiler/arm64/compiler.h
+++ b/compiler/arm64/compiler.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "absl/strings/str_format.h"
+#include "compiler/arm64/register_tracker.h"
+#include "compiler/arm64/runtime_stack.h"
+#include "core/ast.h"
+#include "core/instruction.h"
+
+namespace wasmcc::arm64 {
+
+/**
+ *
+ * The compiler ahead of time knows it's memory layout. We'll reserve the max
+ * stack depth (TODO we should also remove pumping the stack when taking into
+ * account the available registers). And also reserve space on the stack for
+ * persisting locals as well.
+ *
+ * The locals are stored closer to the top of the stack, so that values that are
+ * passed on the stack don't have to be moved. The stack is then placed after
+ * that, and stack values grow *towards* the locals (as that was simpler to
+ * implement).
+ *
+ * Here is a graphical representation of the stack usage.
+ *
+ *  ┌──────────┬───────────────┐
+ *  │  LOCALS  │  STACK        │
+ *  └──────────┴───────────────┘
+ *  0xFFFF                0xFF00
+ */
+class Compiler {
+ public:
+  Compiler(Function::Metadata, asmjit::CodeHolder*);
+  Compiler(const Compiler&) = delete;
+  Compiler& operator=(const Compiler&) = delete;
+  Compiler(Compiler&&) = delete;
+  Compiler& operator=(Compiler&&) = delete;
+  ~Compiler() = default;
+
+  void SetLogger(asmjit::Logger*);
+
+  void Prologue();
+  void Epilogue();
+
+  void operator()(op::ConstI32);
+  void operator()(op::AddI32);
+  void operator()(op::GetLocalI32);
+  void operator()(op::SetLocalI32);
+  void operator()(op::Return);
+
+ private:
+  asmjit::a64::Gp AllocateRegister();
+  asmjit::a64::Gp EnsureInRegister(RuntimeValue*);
+
+  // Annotate the next instruction emitted
+  //
+  // The input string must outlive the next instruction emit, and probably
+  // should only be static strings.
+  void AnnotateNext(const char*);
+
+  // Annotate the next instruction emitted
+  //
+  // the returned string must be alive when the next instruction is emitted
+  // asmjit doesn't free these strings.
+  template <typename... A>
+  [[nodiscard(
+      "the comment must outlie emitting the next instruction")]] std::string
+  AnnotateNext(const absl::FormatSpec<A...>& fmt, A&&... args) {
+    std::string msg = absl::StrFormat(fmt, std::forward<A>(args)...);
+    AnnotateNext(msg.c_str());
+    return msg;
+  }
+
+  // The size of the locals in bytes.
+  int32_t _locals_size_bytes;
+  // A mapping between a local and it's memory offset onto the stack.
+  //
+  // The offset is relative to rsp.
+  absl::FixedArray<int32_t> _locals_stack_offset;
+  std::unique_ptr<RegisterTracker> _reg_tracker;
+  std::unique_ptr<RuntimeStack> _stack;
+
+  Function::Metadata _meta;
+  asmjit::a64::Assembler _asm;
+  asmjit::FuncFrame _frame;
+  asmjit::Label _exit_label;
+};
+
+}  // namespace wasmcc::arm64

--- a/compiler/arm64/register_tracker.cc
+++ b/compiler/arm64/register_tracker.cc
@@ -1,0 +1,20 @@
+#include "compiler/arm64/register_tracker.h"
+
+#include <cstddef>
+
+namespace wasmcc::arm64 {
+
+std::optional<asmjit::a64::Gp> RegisterTracker::TakeUnusedRegister() {
+  for (const asmjit::a64::Gp& reg : kCallerSavedRegisters) {
+    if (!_registers_used_mask.test(reg.id())) {
+      _registers_used_mask.set(reg.id());
+      return reg;
+    }
+  }
+  return std::nullopt;
+}
+
+void RegisterTracker::MarkRegisterUnused(const asmjit::a64::Gp& reg) {
+  _registers_used_mask.reset(reg.id());
+}
+}  // namespace wasmcc::arm64

--- a/compiler/arm64/register_tracker.h
+++ b/compiler/arm64/register_tracker.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <asmjit/a64.h>
+
+#include <array>
+#include <bitset>
+#include <optional>
+
+namespace wasmcc::arm64 {
+
+/**
+ * This class tracks if a given register is in use.
+ *
+ * In the future this class will also likely need to track **where** a register
+ * is in use. So we don't have to do things like always save arguments to the
+ * stack.
+ */
+class RegisterTracker {
+ public:
+  RegisterTracker() = default;
+  RegisterTracker(const RegisterTracker&) = delete;
+  RegisterTracker& operator=(const RegisterTracker&) = delete;
+  RegisterTracker(RegisterTracker&&) = delete;
+  RegisterTracker& operator=(RegisterTracker&&) = delete;
+  ~RegisterTracker() = default;
+
+  /**
+   * Currently, we only use caller saved registers, but we should certainly also
+   * be able to use save callee registers too to resolve some register pressure.
+   */
+  static constexpr std::array kCallerSavedRegisters = {
+      // function args and results
+      asmjit::a64::regs::x0,
+      asmjit::a64::regs::x1,
+      asmjit::a64::regs::x2,
+      asmjit::a64::regs::x3,
+      asmjit::a64::regs::x4,
+      asmjit::a64::regs::x5,
+      asmjit::a64::regs::x6,
+      asmjit::a64::regs::x7,
+      // caller saved
+      asmjit::a64::regs::x9,
+      asmjit::a64::regs::x10,
+      asmjit::a64::regs::x11,
+      asmjit::a64::regs::x12,
+      asmjit::a64::regs::x13,
+      asmjit::a64::regs::x14,
+      asmjit::a64::regs::x15,
+  };
+  static constexpr size_t kNumGeneralPurposeRegisters = 32;
+  using RegisterUsedMask = std::bitset<kNumGeneralPurposeRegisters>;
+
+  std::optional<asmjit::a64::Gp> TakeUnusedRegister();
+
+  void MarkRegisterUnused(const asmjit::a64::Gp&);
+
+ private:
+  RegisterUsedMask _registers_used_mask;
+};
+}  // namespace wasmcc::arm64

--- a/compiler/arm64/register_tracker_test.cc
+++ b/compiler/arm64/register_tracker_test.cc
@@ -1,0 +1,49 @@
+#include "compiler/arm64/register_tracker.h"
+
+#include <gtest/gtest-matchers.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <optional>
+#include <vector>
+
+#include "absl/container/flat_hash_set.h"
+#include "gmock/gmock.h"
+
+template <>
+struct std::hash<asmjit::a64::Gp> {
+  std::size_t operator()(asmjit::a64::Gp const& reg) const noexcept {
+    std::size_t h1 = std::hash<uint32_t>{}(reg.id());
+    std::size_t h2 = std::hash<uint32_t>{}(reg.signature().bits());
+    return h1 ^ (h2 << 1U);
+  }
+};
+
+namespace wasmcc::arm64 {
+
+TEST(RegisterTracker, AllocatesRegisters) {
+  RegisterTracker rt;
+  auto r1 = rt.TakeUnusedRegister();
+  EXPECT_NE(r1, std::nullopt);
+  auto r2 = rt.TakeUnusedRegister();
+  EXPECT_NE(r2, std::nullopt);
+  EXPECT_NE(r1, r2);
+}
+
+TEST(RegisterTracker, CanAllocateAllRegisters) {
+  RegisterTracker rt;
+  std::vector<asmjit::a64::Gp> registers;
+  while (true) {
+    auto reg = rt.TakeUnusedRegister();
+    if (!reg.has_value()) {
+      break;
+    }
+    registers.push_back(*reg);
+  }
+  absl::flat_hash_set<asmjit::a64::Gp> unique(registers.begin(),
+                                              registers.end());
+  EXPECT_THAT(registers, testing::UnorderedElementsAreArray(unique));
+}
+}  // namespace wasmcc::arm64

--- a/compiler/arm64/runtime_stack.cc
+++ b/compiler/arm64/runtime_stack.cc
@@ -1,0 +1,50 @@
+#include "compiler/arm64/runtime_stack.h"
+
+#include <cstdint>
+
+namespace wasmcc::arm64 {
+
+size_t RuntimeValue::size_bytes() const {
+  switch (type) {
+    case ValType::kI32:
+      return sizeof(int32_t);
+    case ValType::kI64:
+      return sizeof(int64_t);
+    case ValType::kF32:
+      return sizeof(float);
+    case ValType::kF64:
+      return sizeof(double);
+    case ValType::kV128:
+      return sizeof(int64_t) * 2;
+    case ValType::kFuncRef:
+    case ValType::kExternRef:
+      return sizeof(void*);
+  }
+}
+
+RuntimeStack::RuntimeStack(size_t max_stack_elements, RegisterTracker* tracker)
+    : _reg_tracker(tracker), _stack(max_stack_elements) {
+  // TODO: We'll need this eventually (I think)
+  (void)_reg_tracker;
+}
+
+RuntimeValue* RuntimeStack::Push(RuntimeValue v) {
+  _stack_memory_offset += int32_t(v.size_bytes());
+  v.stack_pointer = _stack_memory_offset;
+  _stack[_stack_size++] = std::move(v);
+  return Peek();
+}
+RuntimeValue RuntimeStack::Pop() {
+  auto top = std::move(_stack[--_stack_size]);
+  _stack_memory_offset -= int32_t(top.size_bytes());
+  return top;
+}
+RuntimeValue* RuntimeStack::Peek() { return &_stack[_stack_size - 1]; }
+const RuntimeValue* RuntimeStack::Peek() const {
+  return &_stack[_stack_size - 1];
+}
+std::span<RuntimeValue> RuntimeStack::ReverseIterator() {
+  return {_stack.data(), _stack_size};
+}
+
+}  // namespace wasmcc::arm64

--- a/compiler/arm64/runtime_stack.h
+++ b/compiler/arm64/runtime_stack.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <span>
+
+#include "absl/container/fixed_array.h"
+#include "compiler/arm64/register_tracker.h"
+#include "core/value.h"
+
+namespace wasmcc::arm64 {
+
+struct RuntimeValue {
+  // The offset relative to the base of the stack in memory where this stack
+  // value can spill to if not in a register.
+  int32_t stack_pointer = 0;
+  // The register that this value is located in.
+  std::optional<asmjit::a64::Gp> reg;
+  // The type of this register
+  ValType type = ValType::kI32;
+
+  bool operator==(const RuntimeValue&) const = default;
+
+  // The size of this value on the stack in bytes.
+  size_t size_bytes() const;
+};
+
+/**
+ * This class tracks what is on the stack during compilation.
+ *
+ * It also is responsible for tracking stack value's location in stack memory.
+ */
+class RuntimeStack {
+  using UnderlyingType = absl::FixedArray<RuntimeValue>;
+
+ public:
+  RuntimeStack(size_t max_stack_elements, RegisterTracker*);
+  RuntimeStack(const RuntimeStack&) = delete;
+  RuntimeStack& operator=(const RuntimeStack&) = delete;
+  RuntimeStack(RuntimeStack&&) = delete;
+  RuntimeStack& operator=(RuntimeStack&&) = delete;
+  ~RuntimeStack() = default;
+
+  RuntimeValue* Push(RuntimeValue);
+  [[nodiscard]] RuntimeValue Pop();
+  RuntimeValue* Peek();
+  const RuntimeValue* Peek() const;
+
+  std::span<RuntimeValue> ReverseIterator();
+
+  // The current offset in bytes from the bottom of current function's stack.
+  int32_t pointer() const noexcept { return _stack_memory_offset; }
+
+ private:
+  RegisterTracker* _reg_tracker;
+  // The current pointer to the stack in memory, relative to the top of the
+  // stack for this calling frame.
+  int32_t _stack_memory_offset{0};
+  // The current stack size
+  size_t _stack_size{0};
+  UnderlyingType _stack;
+};
+
+}  // namespace wasmcc::arm64

--- a/compiler/arm64/runtime_stack_test.cc
+++ b/compiler/arm64/runtime_stack_test.cc
@@ -1,0 +1,45 @@
+#include "compiler/arm64/runtime_stack.h"
+
+#include <gtest/gtest-matchers.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <optional>
+#include <vector>
+
+#include "core/value.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace wasmcc::arm64 {
+
+constexpr size_t kDefaultStackElements = 32;
+
+TEST(RuntimeStack, EmptyIterator) {
+  RegisterTracker rt;
+  RuntimeStack s(kDefaultStackElements, &rt);
+  EXPECT_THAT(s.ReverseIterator(), testing::IsEmpty());
+}
+
+TEST(RuntimeStack, Push) {
+  RegisterTracker rt;
+  RuntimeStack s(kDefaultStackElements, &rt);
+  auto pushed = s.Push({.type = ValType::kI64});
+  EXPECT_EQ(s.pointer(), sizeof(int64_t));
+  EXPECT_EQ(pushed->stack_pointer, s.pointer());
+  EXPECT_THAT(s.ReverseIterator(), testing::ElementsAre(*pushed));
+}
+
+TEST(RuntimeStack, Pop) {
+  RegisterTracker rt;
+  RuntimeStack s(kDefaultStackElements, &rt);
+  s.Push({.type = ValType::kI64});
+  auto popped = s.Pop();
+  EXPECT_EQ(popped.type, ValType::kI64);
+  EXPECT_EQ(s.pointer(), 0);
+  EXPECT_THAT(s.ReverseIterator(), testing::IsEmpty());
+}
+
+}  // namespace wasmcc::arm64

--- a/compiler/compiler.cc
+++ b/compiler/compiler.cc
@@ -6,6 +6,7 @@
 #include <variant>
 
 #include "base/coro.h"
+#include "compiler/arm64/compiler.h"
 #include "compiler/common/util.h"
 #include "compiler/function.h"
 #include "compiler/x64/compiler.h"
@@ -64,7 +65,7 @@ std::unique_ptr<Compiler> Compiler::CreateNative() {
     case asmjit::Arch::kX64:
       return std::make_unique<CompilerImpl<x64::Compiler>>();
     case asmjit::Arch::kAArch64:
-      // TODO: support me
+      return std::make_unique<CompilerImpl<arm64::Compiler>>();
     default:
       // TODO: Properly crash
       __builtin_unreachable();

--- a/core/value.cc
+++ b/core/value.cc
@@ -1,7 +1,5 @@
 #include "core/value.h"
 
-#include <bits/floatn-common.h>
-
 #include <bit>
 #include <cstdint>
 #include <exception>


### PR DESCRIPTION
Add initial arm64 compiler

Right now some of the register and runtime stack code is just duplicated.
I'm not sure if they will ever drift, but I will followup refactoring them
to use asmjit's helpers to pull those out into compiler/common.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/rockwotj/wasmcc/pull/9).
* #10
* __->__ #9