### PR TITLE
Extract out function frame

### DIFF
--- a/compiler/arm64/call_convention.cc
+++ b/compiler/arm64/call_convention.cc
@@ -2,6 +2,11 @@
 
 namespace wasmcc::arm64 {
 
+GpReg Cast(const GpReg& reg, ValType vt) {
+  GpReg reg32 = reg.w();
+  GpReg reg64 = reg.x();
+  return IsValType32Bit(vt) ? reg32 : reg64;
+}
 const RegisterMask<GpReg> CallingConvention::kGpCalleeSavedRegisters(
     {asmjit::a64::x19, asmjit::a64::x20, asmjit::a64::x21, asmjit::a64::x22,
      asmjit::a64::x23, asmjit::a64::x24, asmjit::a64::x25, asmjit::a64::x26,

--- a/compiler/arm64/call_convention.h
+++ b/compiler/arm64/call_convention.h
@@ -6,11 +6,14 @@
 #include <initializer_list>
 
 #include "compiler/common/call_convention.h"
+#include "core/value.h"
 
 namespace wasmcc::arm64 {
 using GpReg = asmjit::a64::Gp;
 using VecReg = asmjit::a64::Vec;
 constexpr GpReg kSpReg = asmjit::a64::sp;
+
+GpReg Cast(const GpReg& reg, ValType vt);
 
 // The AArch64 calling convention, it's the same on all platforms 🙌
 struct CallingConvention {

--- a/compiler/arm64/compiler.cc
+++ b/compiler/arm64/compiler.cc
@@ -19,91 +19,28 @@ namespace a64 = asmjit::a64;
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 static ThrowingErrorHandler kErrorHandler;
 
-a64::Gp Cast(const a64::Gp& reg, ValType vt) {
-  a64::Gp reg32 = reg.w();
-  a64::Gp reg64 = reg.x();
-  return IsValType32Bit(vt) ? reg32 : reg64;
-}
-
-asmjit::TypeId ValTypeToId(ValType vt) {
-  switch (vt) {
-    case ValType::kI32:
-      return asmjit::TypeId::kInt32;
-    case ValType::kI64:
-      return asmjit::TypeId::kInt64;
-    case ValType::kF32:
-      return asmjit::TypeId::kFloat32;
-    case ValType::kF64:
-      return asmjit::TypeId::kFloat64;
-    case ValType::kV128:
-      return asmjit::TypeId::kInt8x16;
-    case ValType::kFuncRef:
-    case ValType::kExternRef:
-      return asmjit::TypeId::kUIntPtr;
-    default:
-      __builtin_unreachable();
-  }
-}
 }  // namespace
 
 Compiler::Compiler(Function::Metadata meta, asmjit::CodeHolder* holder)
-    : _locals_size_bytes(0),  // To be calculated
-      _locals_stack_offset(meta.locals.size() +
-                           meta.signature.parameter_types.size()),
-      _reg_tracker(std::make_unique<RegisterTracker>()),
+    : _reg_tracker(std::make_unique<RegisterTracker>()),
       _stack(std::make_unique<RuntimeStack>(meta.max_stack_elements)),
       _meta(std::move(meta)),
+      _frame(_meta),
       _asm(holder),
       _exit_label(_asm.newLabel()) {
 #ifndef NDEBUG
   _asm.addDiagnosticOptions(asmjit::DiagnosticOptions::kValidateAssembler);
 #endif
   _asm.setErrorHandler(&kErrorHandler);
+}
 
-  // Initially record the stack offset relative to the bottom of the stack
-  size_t i = 0;
-  for (const auto& type : _meta.signature.parameter_types) {
-    _locals_stack_offset[i++] = _locals_size_bytes;
-    _locals_size_bytes += int32_t(ValTypeSizeBytes(type));
-  }
-  for (const auto& type : _meta.locals) {
-    _locals_stack_offset[i++] = _locals_size_bytes;
-    _locals_size_bytes += int32_t(ValTypeSizeBytes(type));
-  }
-  // Now that we've calculated the full stack size, adjust the offset to be
-  // relative to the top of the stack.
-  for (i = 0; i < _locals_stack_offset.size(); ++i) {
-    _locals_stack_offset[i] -=
-        _locals_size_bytes + int32_t(_meta.max_stack_size_bytes);
-  }
-  // NOTE: This only supports upto 16 arguments.
-  asmjit::FuncSignatureBuilder b;
-  for (ValType vt : _meta.signature.parameter_types) {
-    b.addArg(ValTypeToId(vt));
-  }
-  switch (_meta.signature.result_types.size()) {
-    case 0:
-      b.setRet(asmjit::TypeId::kVoid);
-      break;
-    case 1:
-      b.addArg(ValTypeToId(_meta.signature.result_types.front()));
-    default:
-      // A pointer to a structure of result values
-      b.setRet(asmjit::TypeId::kUIntPtr);
-      break;
-  }
-  asmjit::FuncDetail func_detail;
-  Check(func_detail.init(b, _asm.environment()));
-  Check(_frame.init(func_detail));
-  // TODO: There are cases where it makes sense to save some caller registers:
-  // _frame.setAllDirty(asmjit::RegGroup::kGp);
-  Check(_frame.finalize());
-  _asm.emitProlog(_frame);
+void Compiler::SetLogger(asmjit::Logger* logger) { _asm.setLogger(logger); }
+void Compiler::AnnotateNext(const char* s) { _asm.setInlineComment(s); }
+
+void Compiler::Prologue() {
   AnnotateNext("set locals stack space");
   // rsp -= <stack_size>
-  _asm.sub(a64::sp, a64::sp,
-           AlignUp<uint32_t>(_meta.max_stack_size_bytes + _locals_size_bytes,
-                             CallingConvention::kStackAlignment));
+  _asm.sub(a64::sp, a64::sp, _frame.StackSizeBytes());
   // TODO: We should lazily spill these onto the stack, and handle passing
   // values by stack
   for (size_t i = 0; i < _meta.signature.parameter_types.size(); ++i) {
@@ -111,14 +48,9 @@ Compiler::Compiler(Function::Metadata meta, asmjit::CodeHolder* holder)
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
     const auto& reg = Cast(CallingConvention::kGpArgs[i], vt);
     auto comment = AnnotateNext("SaveLocalToStack(%d)", i);
-    _asm.str(reg, a64::Mem(a64::regs::sp, _locals_stack_offset[i]));
+    _asm.str(reg, a64::Mem(a64::regs::sp, _frame.LocalStackOffset(i)));
   }
 }
-
-void Compiler::SetLogger(asmjit::Logger* logger) { _asm.setLogger(logger); }
-void Compiler::AnnotateNext(const char* s) { _asm.setInlineComment(s); }
-
-void Compiler::Prologue() {}
 void Compiler::Epilogue() {
   AnnotateNext("epilog start");
   _asm.bind(_exit_label);
@@ -133,10 +65,8 @@ void Compiler::Epilogue() {
     }
   }
   // rsp += <stack size>
-  _asm.add(a64::sp, a64::sp,
-           AlignUp<uint32_t>(_meta.max_stack_size_bytes + _locals_size_bytes,
-                             CallingConvention::kStackAlignment));
-  _asm.emitEpilog(_frame);
+  _asm.add(a64::sp, a64::sp, _frame.StackSizeBytes());
+  _asm.ret(a64::x30);
 }
 
 void Compiler::operator()(op::ConstI32 op) {
@@ -161,14 +91,14 @@ void Compiler::operator()(op::GetLocalI32 op) {
   _stack->Push({.type = ValType::kI32});
   auto* top = _stack->Peek();
   top->reg = AllocateRegister();
-  auto offset = _locals_stack_offset[op.idx];
+  auto offset = _frame.LocalStackOffset(op.idx);
   auto comment = AnnotateNext("GetLocalI32(%d)", op.idx);
   _asm.ldr(top->reg->w(), a64::Mem(a64::sp, offset));
 }
 void Compiler::operator()(op::SetLocalI32 op) {
   auto v = _stack->Pop();
   auto v_reg = EnsureInRegister(&v);
-  auto offset = _locals_stack_offset[op.idx];
+  auto offset = _frame.LocalStackOffset(op.idx);
   auto comment = AnnotateNext("SetLocalI32(%d)", op.idx);
   _asm.ldr(v_reg, a64::Mem(a64::sp, offset));
   _reg_tracker->MarkRegisterUnused(v_reg);

--- a/compiler/arm64/compiler.h
+++ b/compiler/arm64/compiler.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "absl/strings/str_format.h"
+#include "compiler/arm64/call_convention.h"
 #include "compiler/arm64/register_tracker.h"
 #include "compiler/arm64/runtime_stack.h"
+#include "compiler/common/function_frame.h"
 #include "core/ast.h"
 #include "core/instruction.h"
 
@@ -48,8 +50,8 @@ class Compiler {
   void operator()(op::Return);
 
  private:
-  asmjit::a64::Gp AllocateRegister();
-  asmjit::a64::Gp EnsureInRegister(RuntimeValue*);
+  GpReg AllocateRegister();
+  GpReg EnsureInRegister(RuntimeValue*);
 
   // Annotate the next instruction emitted
   //
@@ -70,18 +72,12 @@ class Compiler {
     return msg;
   }
 
-  // The size of the locals in bytes.
-  int32_t _locals_size_bytes;
-  // A mapping between a local and it's memory offset onto the stack.
-  //
-  // The offset is relative to rsp.
-  absl::FixedArray<int32_t> _locals_stack_offset;
   std::unique_ptr<RegisterTracker> _reg_tracker;
   std::unique_ptr<RuntimeStack> _stack;
 
   Function::Metadata _meta;
+  FunctionFrame<CallingConvention> _frame;
   asmjit::a64::Assembler _asm;
-  asmjit::FuncFrame _frame;
   asmjit::Label _exit_label;
 };
 

--- a/compiler/common/BUILD
+++ b/compiler/common/BUILD
@@ -9,12 +9,14 @@ cc_library(
         "call_convention.h",
         "register_tracker.h",
         "runtime_stack.h",
+        "function_frame.h",
         "util.h",
     ],
     visibility = [
         "//compiler:__subpackages__",
     ],
     deps = [
+        "//base:align",
         "//third_party/asmjit",
     ],
 )

--- a/compiler/common/function_frame.h
+++ b/compiler/common/function_frame.h
@@ -1,0 +1,76 @@
+#pragma once
+#include "base/align.h"
+#include "compiler/common/call_convention.h"
+#include "core/ast.h"
+
+namespace wasmcc {
+
+/**
+ *
+ * The function ahead of time knows it's memory layout thanks to how WASM is
+ * designed. We'll reserve the max stack depth (TODO we should also remove
+ * pumping the stack when taking into account the available registers). And also
+ * reserve space on the stack for persisting locals as well.
+ *
+ * The locals are stored closer to the top of the stack, so that values that are
+ * passed on the stack don't have to be moved. The stack is then placed after
+ * that, and stack values grow *towards* the locals (as that was simpler to
+ * implement).
+ *
+ * Here is a graphical representation of the stack usage.
+ *
+ *  ┌──────────┬───────────────┐
+ *  │  LOCALS  │  STACK        │
+ *  └──────────┴───────────────┘
+ *  0xFFFF                0xFF00
+ */
+template <CallingConvention CC>
+class FunctionFrame {
+ public:
+  explicit FunctionFrame(Function::Metadata meta);
+
+  /* The size of the stack. */
+  int32_t StackSizeBytes() const noexcept {
+    // TODO: This can be optimized, as there are registers around to hold the
+    // stack size.
+    return AlignUp<uint32_t>(_locals_size_bytes + _meta.max_stack_size_bytes,
+                             CC::kStackAlignment);
+  }
+
+  int32_t LocalStackOffset(size_t idx) const {
+    return _locals_stack_offset[idx];
+  }
+
+ private:
+  Function::Metadata _meta;
+  // The size of the locals in bytes.
+  int32_t _locals_size_bytes{0};
+  // A mapping between a local and it's memory offset onto the stack.
+  //
+  // The offset is relative to rsp.
+  absl::FixedArray<int32_t> _locals_stack_offset;
+};
+
+template <CallingConvention CC>
+FunctionFrame<CC>::FunctionFrame(Function::Metadata meta)
+    : _meta(std::move(meta)),
+      _locals_stack_offset(_meta.locals.size() +
+                           _meta.signature.parameter_types.size()) {
+  // Initially record the stack offset relative to the bottom of the stack
+  size_t i = 0;
+  for (const auto& type : _meta.signature.parameter_types) {
+    _locals_stack_offset[i++] = _locals_size_bytes;
+    _locals_size_bytes += int32_t(ValTypeSizeBytes(type));
+  }
+  for (const auto& type : _meta.locals) {
+    _locals_stack_offset[i++] = _locals_size_bytes;
+    _locals_size_bytes += int32_t(ValTypeSizeBytes(type));
+  }
+  // Now that we've calculated the full stack size, adjust the offset to be
+  // relative to the top of the stack.
+  for (i = 0; i < _locals_stack_offset.size(); ++i) {
+    _locals_stack_offset[i] -= StackSizeBytes();
+  }
+}
+
+}  // namespace wasmcc

--- a/compiler/compiler.cc
+++ b/compiler/compiler.cc
@@ -22,6 +22,8 @@ class CompilerImpl : public Compiler {
 
   co::Future<CompiledFunction> Compile(Function func) override {
     T func_compiler(func.meta, &_code_holder);
+    asmjit::StringLogger logger;
+    func_compiler.SetLogger(&logger);
     func_compiler.Prologue();
     for (const auto& expr : func.body) {
       std::visit(func_compiler, expr);
@@ -30,6 +32,7 @@ class CompilerImpl : public Compiler {
     func_compiler.Epilogue();
     void* compiled = nullptr;
     Check(_runtime.add(&compiled, &_code_holder));
+    std::cout << logger.data() << std::endl;
     co_return CompiledFunction(compiled);
   }
 

--- a/compiler/x64/call_convention.cc
+++ b/compiler/x64/call_convention.cc
@@ -2,6 +2,11 @@
 
 namespace wasmcc::x64 {
 
+GpReg Cast(const GpReg& reg, ValType vt) {
+  GpReg reg32 = reg.r32();
+  GpReg reg64 = reg.r64();
+  return IsValType32Bit(vt) ? reg32 : reg64;
+}
 const RegisterMask<GpReg> CallingConvention::kGpCalleeSavedRegisters({
     asmjit::x86::rbx,
     asmjit::x86::rbp,

--- a/compiler/x64/call_convention.h
+++ b/compiler/x64/call_convention.h
@@ -5,11 +5,15 @@
 #include <array>
 
 #include "compiler/common/call_convention.h"
+#include "core/value.h"
 
 namespace wasmcc::x64 {
 using GpReg = asmjit::x86::Gp;
 using VecReg = asmjit::x86::Vec;
 static constexpr GpReg kSpReg = asmjit::x86::rsp;
+
+GpReg Cast(const GpReg& reg, ValType vt);
+
 // The SystemV calling convention, which is used on Mac + Linux.
 struct CallingConvention {
   using GpReg = GpReg;

--- a/compiler/x64/compiler.h
+++ b/compiler/x64/compiler.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "absl/strings/str_format.h"
+#include "compiler/common/function_frame.h"
+#include "compiler/x64/call_convention.h"
 #include "compiler/x64/register_tracker.h"
 #include "compiler/x64/runtime_stack.h"
 #include "core/ast.h"
@@ -48,8 +50,8 @@ class Compiler {
   void operator()(op::Return);
 
  private:
-  asmjit::x86::Gp AllocateRegister();
-  asmjit::x86::Gp EnsureInRegister(RuntimeValue*);
+  GpReg AllocateRegister();
+  GpReg EnsureInRegister(RuntimeValue*);
 
   // Annotate the next instruction emitted
   //
@@ -70,18 +72,12 @@ class Compiler {
     return msg;
   }
 
-  // The size of the locals in bytes.
-  int32_t _locals_size_bytes;
-  // A mapping between a local and it's memory offset onto the stack.
-  //
-  // The offset is relative to rsp.
-  absl::FixedArray<int32_t> _locals_stack_offset;
   std::unique_ptr<RegisterTracker> _reg_tracker;
   std::unique_ptr<RuntimeStack> _stack;
 
   Function::Metadata _meta;
   asmjit::x86::Assembler _asm;
-  asmjit::FuncFrame _frame;
+  FunctionFrame<CallingConvention> _frame;
   asmjit::Label _exit_label;
 };
 


### PR DESCRIPTION
Extract out function frame

used to compute the stack size and accessing locals on the stack.
