### PR TITLE
Hookup VMThread into VM

### DIFF
--- a/compiler/compiler.h
+++ b/compiler/compiler.h
@@ -22,8 +22,8 @@ class Compiler {
   Compiler() = default;
   Compiler(const Compiler&) = delete;
   Compiler& operator=(const Compiler&) = delete;
-  Compiler(Compiler&&) = default;
-  Compiler& operator=(Compiler&&) = default;
+  Compiler(Compiler&&) noexcept = default;
+  Compiler& operator=(Compiler&&) noexcept = default;
   virtual ~Compiler() = default;
 
   /**

--- a/runtime/BUILD
+++ b/runtime/BUILD
@@ -1,6 +1,6 @@
 cc_library(
   name = "runtime",
-  srcs = ["vm.cc"],
+  srcs = ["vm.cc", "function_handle.cc"],
   hdrs = [
     "vm.h",
     "function_handle.h",
@@ -10,6 +10,7 @@ cc_library(
     "//compiler:module",
     "//core:ast",
     "//base:type_traits",
+    "//third_party/absl/functional:any_invocable",
     "//runtime/thread",
   ],
 )

--- a/runtime/function_handle.cc
+++ b/runtime/function_handle.cc
@@ -1,0 +1,23 @@
+#include "runtime/function_handle.h"
+
+#include "base/assert.h"
+#include "runtime/thread/thread.h"
+
+namespace wasmcc::runtime {
+
+DynamicComputation::DynamicComputation(VMThread* t) : _thread(t) {}
+void DynamicComputation::Execute() {
+  if (_thread->state() == VMThread::State::kSuspended) {
+    _thread->Resume();
+  }
+}
+void DynamicComputation::Cancel() {
+  if (_thread->state() == VMThread::State::kSuspended) {
+    _thread->Stop();
+  }
+}
+bool DynamicComputation::IsDone() const noexcept {
+  return _thread->state() == VMThread::State::kStopped;
+}
+
+}  // namespace wasmcc::runtime

--- a/runtime/function_handle.h
+++ b/runtime/function_handle.h
@@ -1,25 +1,109 @@
 #pragma once
+#include <memory>
 #include <tuple>
 #include <utility>
 
+#include "absl/functional/any_invocable.h"
 #include "base/type_traits.h"
 #include "compiler/module.h"
 
 namespace wasmcc {
 
+template <typename Result>
+class Computation;
+
+/**
+ * A handle to a VM defined function.
+ *
+ * These can be looked up a head of time and repeated invoked. There is a very
+ * small setup cost to actually creating a handle, but most work is deferred to
+ * at that time.
+ *
+ * You may only invoke a single FunctionHandle at once, and must either call the
+ * resulting `Computation's` `Execute` method until `IsDone()` is true or call
+ * `Stop()`.
+ */
 template <typename Signature>
 class FunctionHandle {
+  using ResultType = FunctionTraits<Signature>::result_type;
+  using ArgTypes = FunctionTraits<Signature>::arg_types;
+  using UnderlyingType =
+      absl::AnyInvocable<std::unique_ptr<Computation<ResultType>>(ArgTypes&&)>;
+
  public:
-  explicit FunctionHandle(CompiledFunction c) : _compiled(std::move(c)){};
+  explicit FunctionHandle(UnderlyingType u) : _underlying(std::move(u)) {}
 
   template <typename... Args>
-  decltype(auto) invoke(Args&&... args) {
-    return _compiled.apply<Signature>(
-        std::make_tuple<Args...>(std::forward<Args>(args)...));
+  std::unique_ptr<Computation<ResultType>> Invoke(Args&&... args) {
+    return _underlying(std::make_tuple(std::forward<Args>(args)...));
   }
 
  private:
-  CompiledFunction _compiled;
+  UnderlyingType _underlying;
+};
+
+namespace runtime {
+class VMThread;
+/** An untyped version of `Computation`. */
+class DynamicComputation {
+ public:
+  explicit DynamicComputation(VMThread*);
+  DynamicComputation(const DynamicComputation&) = delete;
+  DynamicComputation& operator=(const DynamicComputation&) = delete;
+  DynamicComputation(DynamicComputation&&) noexcept = default;
+  DynamicComputation& operator=(DynamicComputation&&) noexcept = default;
+  ~DynamicComputation() = default;
+
+  void Execute();
+  void Cancel();
+  bool IsDone() const noexcept;
+
+ private:
+  VMThread* _thread;
+};
+}  // namespace runtime
+
+/**
+ * A running function within the VM.
+ *
+ * This encapsulates the behavior that the VM can yield execution back to the
+ * host, so `Execute()` must continue to be called to yield control back to the
+ * VM.
+ *
+ * If `Execute()` is not called until completion, then `Cancel()` must be
+ * called.
+ *
+ */
+template <typename Result>
+class Computation {
+ public:
+  // Computation needs a stable pointer, so it's not moveable or copyable.
+  Computation(const Computation&) = delete;
+  Computation& operator=(const Computation&) = delete;
+  Computation(Computation&&) = delete;
+  Computation& operator=(Computation&&) = delete;
+  ~Computation() = default;
+
+  // Continue to run the function.
+  void Execute() { _dyn.Execute(); }
+
+  // Cancel this computation so another can run or the VM can be shutdown.
+  void Cancel() { _dyn.Cancel(); }
+
+  // If this computation has finished executing.
+  bool IsDone() const noexcept { return _dyn.IsDone(); }
+
+  // Must wait to call until `IsDone()` returns true.
+  Result GetResult() const noexcept { return _result; };
+
+ private:
+  friend class VM;
+
+  Computation() : _dyn(nullptr) {}
+
+  runtime::DynamicComputation _dyn;
+  // NOTE: This should be a variant when we have traps.
+  Result _result{};
 };
 
 }  // namespace wasmcc

--- a/runtime/thread/thread.h
+++ b/runtime/thread/thread.h
@@ -9,15 +9,18 @@ namespace wasmcc::runtime {
 struct ThreadStack;
 using StackState = std::unique_ptr<ThreadStack, void (*)(ThreadStack*)>;
 
+// Default to 64kb stack size
+constexpr size_t kDefaultStackSize = 1024L * 64;
+
 struct VMThreadConfiguration {
   /** The size of the native runtime stack. */
-  size_t stack_size;
+  size_t stack_size = kDefaultStackSize;
   /**
    * If true enable 4k guard pages on each side of the stack,
    * and protect the memory, which means that if there is a stack
    * {over,under}flow that the process is aborted.
    */
-  bool enable_guard_pages;
+  bool enable_guard_pages = true;
 };
 
 /**
@@ -48,11 +51,11 @@ class VMThread {
   ~VMThread();
 
   /**
-   * Create a new thread running the specified function with a stack the size of
-   * `stack_size`.
+   * Create a new thread running the specified function with optional
+   * configuration overrides.
    */
   static std::unique_ptr<VMThread> Create(absl::AnyInvocable<void()>,
-                                          VMThreadConfiguration);
+                                          VMThreadConfiguration = {});
 
   /**
    * Resume (or start) the thread.

--- a/runtime/vm.cc
+++ b/runtime/vm.cc
@@ -1,12 +1,23 @@
 #include "runtime/vm.h"
 
+#include <exception>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <stdexcept>
 #include <utility>
 
+#include "base/assert.h"
+#include "runtime/function_handle.h"
+#include "runtime/thread/thread.h"
+
 namespace wasmcc {
-namespace {
+namespace runtime {
 class VMImpl final : public VM {
  public:
-  explicit VMImpl(CompiledModule compiled) : _compiled(std::move(compiled)) {}
+  explicit VMImpl(CompiledModule compiled)
+      : _compiled(std::move(compiled)),
+        _thread(runtime::VMThread::Create([this] { RunInternal(); }, {})) {}
 
   std::optional<CompiledFunction> LookupFunctionHandleDynamic(
       const Name& name, const FunctionSignature& signature) final {
@@ -21,12 +32,38 @@ class VMImpl final : public VM {
     return compiled;
   }
 
+  DynamicComputation InvokeDynamic(absl::AnyInvocable<void()> fn) final {
+    if (_current_fn || _thread->state() != runtime::VMThread::State::kStopped) {
+      throw std::runtime_error(
+          "cannot run a function when one is already executing.");
+    }
+    _current_fn = std::move(fn);
+    auto comp = runtime::DynamicComputation(_thread.get());
+    // We immediately yield, but this ensures that _current_fn is exchanged, so
+    // it's possible to immediately throw away the result of the computation.
+    _thread->Resume();
+    return comp;
+  }
+
  private:
+  void RunInternal() {
+    // Clear _current function immediately so that there
+    // is no issue with _thread->Stop() being able to be reset.
+    auto fn = std::exchange(_current_fn, std::nullopt);
+    Assert(fn.has_value(), "run_internal called without anything to run");
+    // Pause so the computation is ready
+    VMThread::Yield();
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    (*fn)();
+  }
+
+  std::optional<absl::AnyInvocable<void()>> _current_fn;
   CompiledModule _compiled;
+  std::unique_ptr<runtime::VMThread> _thread;
 };
-}  // namespace
+}  // namespace runtime
 
 std::unique_ptr<VM> VM::Create(CompiledModule compiled) {
-  return std::make_unique<VMImpl>(std::move(compiled));
+  return std::make_unique<runtime::VMImpl>(std::move(compiled));
 }
 }  // namespace wasmcc

--- a/runtime/vm_test.cc
+++ b/runtime/vm_test.cc
@@ -37,7 +37,11 @@ TEST_F(VMTest, Works) {
   auto func = vm->LookupFunctionHandle<int (*)(int, int)>(Name("add"));
   ASSERT_NE(func, std::nullopt);
   // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-  EXPECT_EQ(func->invoke(1, 1), 2);
+  auto computation = func->Invoke(1, 1);
+  while (!computation->IsDone()) {
+    computation->Execute();
+  }
+  EXPECT_EQ(computation->GetResult(), 2);
 }
 
 }  // namespace wasmcc


### PR DESCRIPTION
Hookup VMThread into VM

This means that now we execute WASM generated assembly on a seperate stack,
which will be important to isolate the host stack and do bounds checking
on the stack. This also means we can force WASM code to periodically
yield execution back to the host with this machinery too.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/rockwotj/wasmcc/pull/19).
* #21
* #20
* __->__ #19