### PR TITLE
Simplify if/then/else IR

### DIFF
--- a/compiler/arm64/compiler.cc
+++ b/compiler/arm64/compiler.cc
@@ -104,13 +104,13 @@ void Compiler::operator()(const op::SetLocalI32& op) {
   _reg_tracker->MarkRegisterUnused(v_reg);
 }
 void Compiler::operator()(const op::Return&) { _asm.b(_exit_label); }
-void Compiler::operator()(const op::LabelBlockStart&) {
+void Compiler::operator()(const op::Label&) {
   // TODO
 }
-void Compiler::operator()(const op::LabelBlockAlternative&) {
+void Compiler::operator()(const op::Br&) {
   // TODO
 }
-void Compiler::operator()(const op::LabelBlockEnd&) {
+void Compiler::operator()(const op::BrIf&) {
   // TODO
 }
 

--- a/compiler/arm64/compiler.h
+++ b/compiler/arm64/compiler.h
@@ -48,9 +48,9 @@ class Compiler {
   void operator()(const op::GetLocalI32&);
   void operator()(const op::SetLocalI32&);
   void operator()(const op::Return&);
-  void operator()(const op::LabelBlockStart&);
-  void operator()(const op::LabelBlockAlternative&);
-  void operator()(const op::LabelBlockEnd&);
+  void operator()(const op::Label&);
+  void operator()(const op::Br&);
+  void operator()(const op::BrIf&);
 
  private:
   GpReg AllocateRegister();

--- a/compiler/x64/compiler.cc
+++ b/compiler/x64/compiler.cc
@@ -103,13 +103,13 @@ void Compiler::operator()(const op::SetLocalI32& op) {
   _reg_tracker->MarkRegisterUnused(v_reg);
 }
 void Compiler::operator()(const op::Return&) { _asm.jmp(_exit_label); }
-void Compiler::operator()(const op::LabelBlockStart&) {
+void Compiler::operator()(const op::Label&) {
   // TODO
 }
-void Compiler::operator()(const op::LabelBlockAlternative&) {
+void Compiler::operator()(const op::Br&) {
   // TODO
 }
-void Compiler::operator()(const op::LabelBlockEnd&) {
+void Compiler::operator()(const op::BrIf&) {
   // TODO
 }
 

--- a/compiler/x64/compiler.h
+++ b/compiler/x64/compiler.h
@@ -48,9 +48,9 @@ class Compiler {
   void operator()(const op::GetLocalI32&);
   void operator()(const op::SetLocalI32&);
   void operator()(const op::Return&);
-  void operator()(const op::LabelBlockStart&);
-  void operator()(const op::LabelBlockAlternative&);
-  void operator()(const op::LabelBlockEnd&);
+  void operator()(const op::Label&);
+  void operator()(const op::Br&);
+  void operator()(const op::BrIf&);
 
  private:
   GpReg AllocateRegister();

--- a/core/BUILD
+++ b/core/BUILD
@@ -11,7 +11,12 @@ cc_library(
 cc_library(
     name = "instruction",
     hdrs = ["instruction.h"],
-    deps = [":value"],
+    srcs = ["instruction.cc"],
+    deps = [
+      ":value",
+      "//base:named_type",
+      "//third_party/absl/strings:str_format",
+    ],
 )
 
 cc_library(

--- a/core/ast.h
+++ b/core/ast.h
@@ -12,12 +12,11 @@
 
 namespace wasmcc {
 
-struct FunctionSignature {
+struct BlockType {
   std::vector<ValType> parameter_types;
   std::vector<ValType> result_types;
 
-  friend bool operator==(const FunctionSignature&,
-                         const FunctionSignature&) = default;
+  friend bool operator==(const BlockType&, const BlockType&) = default;
 };
 
 struct Limits {
@@ -75,7 +74,7 @@ struct ModuleExport {
 
 struct Function {
   struct Metadata {
-    FunctionSignature signature;
+    BlockType signature;
     std::vector<ValType> locals;
     uint32_t max_stack_size_bytes;
     uint32_t max_stack_elements;

--- a/core/instruction.cc
+++ b/core/instruction.cc
@@ -1,0 +1,11 @@
+#include "core/instruction.h"
+
+#include "absl/strings/str_format.h"
+
+namespace wasmcc {
+
+LabelId MakeLabelId(std::string_view name, int32_t id) {
+  return LabelId(absl::StrFormat("%s_%d", name, id));
+}
+
+}  // namespace wasmcc

--- a/parser/BUILD
+++ b/parser/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "//leb128",
         "//third_party/absl/container:flat_hash_set",
         "//third_party/absl/strings:str_format",
+        "//third_party/absl/functional:any_invocable",
     ],
 )
 

--- a/parser/validator.cc
+++ b/parser/validator.cc
@@ -61,7 +61,7 @@ std::ostream& operator<<(std::ostream& os, ValidationType vt) {
       __builtin_unreachable();
   }
 }
-FunctionValidator::FunctionValidator(FunctionSignature ft,
+FunctionValidator::FunctionValidator(BlockType ft,
                                      const std::vector<ValType>& locals)
     : _locals(std::move(ft.parameter_types)),
       _returns(std::move(ft.result_types)) {
@@ -97,13 +97,13 @@ void FunctionValidator::operator()(const op::Return&) {
   // Mark the current block as unreachable.
   _unreachable = true;
 }
-void FunctionValidator::operator()(const op::LabelBlockStart&) {
+void FunctionValidator::operator()(const op::Label&) {
   // TODO: Handle
 }
-void FunctionValidator::operator()(const op::LabelBlockAlternative&) {
+void FunctionValidator::operator()(const op::Br&) {
   // TODO: Handle
 }
-void FunctionValidator::operator()(const op::LabelBlockEnd&) {
+void FunctionValidator::operator()(const op::BrIf&) {
   // TODO: Handle
 }
 

--- a/parser/validator.h
+++ b/parser/validator.h
@@ -58,7 +58,7 @@ class ValidationType {
  */
 class FunctionValidator {
  public:
-  FunctionValidator(FunctionSignature, const std::vector<ValType>& locals);
+  FunctionValidator(BlockType, const std::vector<ValType>& locals);
 
   // The maximum number of elements that are ever on the stack at
   // once.
@@ -71,9 +71,9 @@ class FunctionValidator {
   void operator()(const op::GetLocalI32&);
   void operator()(const op::SetLocalI32&);
   void operator()(const op::Return&);
-  void operator()(const op::LabelBlockStart&);
-  void operator()(const op::LabelBlockAlternative&);
-  void operator()(const op::LabelBlockEnd&);
+  void operator()(const op::Label&);
+  void operator()(const op::Br&);
+  void operator()(const op::BrIf&);
 
   void Finalize();
 

--- a/parser/validator_test.cc
+++ b/parser/validator_test.cc
@@ -47,7 +47,7 @@ std::vector<ValType> AsWasmTypes() {
 
 template <typename R, typename... A>
 void check_instructions(const std::initializer_list<Instruction>& ops) {
-  FunctionSignature ft{.parameter_types = AsWasmTypes<A...>()};
+  BlockType ft{.parameter_types = AsWasmTypes<A...>()};
   if constexpr (!std::is_void_v<R>) {
     auto vt = AsWasmType<R>();
     ft.result_types.push_back(vt);

--- a/runtime/signature_converter.h
+++ b/runtime/signature_converter.h
@@ -51,9 +51,9 @@ std::vector<ValType> ConvertNativeSignatureToWasm() {
  * container, but otherwise could be done).
  */
 template <typename Signature>
-FunctionSignature SignatureFromNative() {
+BlockType SignatureFromNative() {
   using Func = FunctionTraits<Signature>;
-  FunctionSignature sig;
+  BlockType sig;
   sig.parameter_types =
       ConvertNativeSignatureToWasm<typename Func::arg_types>();
   if constexpr (!std::is_void_v<typename Func::result_type>) {

--- a/runtime/vm.cc
+++ b/runtime/vm.cc
@@ -20,7 +20,7 @@ class VMImpl final : public VM {
         _thread(runtime::VMThread::Create([this] { RunInternal(); }, {})) {}
 
   std::optional<CompiledFunction> LookupFunctionHandleDynamic(
-      const Name& name, const FunctionSignature& signature) final {
+      const Name& name, const BlockType& signature) final {
     auto it = _compiled.exported_functions.find(name);
     if (it == _compiled.exported_functions.end()) {
       return std::nullopt;

--- a/runtime/vm.h
+++ b/runtime/vm.h
@@ -50,7 +50,7 @@ class VM {
    * Dynamically lookup a function with the given signature.
    */
   virtual std::optional<CompiledFunction> LookupFunctionHandleDynamic(
-      const Name&, const FunctionSignature&) = 0;
+      const Name&, const BlockType&) = 0;
 
   /**
    * Run the specified compiled function within the VM's thread and stack.


### PR DESCRIPTION
Simplify if/then/else IR

Directly emit to an IR that is optimized for the compiler.

This will simplify the compiler implementation. It's not quite clear
if we should have an alternative IR for the validator, but in the
meantime I'm planning on just manipulating the control frames in the
parser directly.
